### PR TITLE
Fix bug regarding passing in no args to getMovie()

### DIFF
--- a/PyArr/radarr_api.py
+++ b/PyArr/radarr_api.py
@@ -145,10 +145,8 @@ class RadarrAPI(RequestAPI):
                 json response
 
         """
-        movieId = args[0]
-
-        if len(movieId) == 1 and isinstance(movieId, (int)):
-            path = f"/api/movie/{movieId}"
+        if len(args) == 1:
+            path = f"/api/movie/{args[0]}"
         else:
             path = "/api/movie"
 


### PR DESCRIPTION
Now `getMovie()` has 1:1 code parity with `getSeries()`.

If passing in no arguments, `getMovie()` would crash due to indexing to element 0 on a NoneType.