### PR TITLE
fix: resolves issue with naming of add_movies foldernames

### DIFF
--- a/pyarr/radarr_api_v3.py
+++ b/pyarr/radarr_api_v3.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 from .request_api import RequestAPI
+from os import path
 
 
 class RadarrAPIv3(RequestAPI):
@@ -87,7 +88,7 @@ class RadarrAPIv3(RequestAPI):
 
         movie_json = {
             "title": s_dict[0]["title"],
-            "path": rootDir + s_dict[0]["title"],
+            "rootFolderPath": rootDir,
             "qualityProfileId": qualityProfileId,
             "year": s_dict[0]["year"],
             "tmdbId": s_dict[0]["tmdbId"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyarr"
-version = "1.0.1"
+version = "1.0.2"
 description = "A Sonarr and Radarr API Wrapper"
 authors = ["Steven Marks <marksie1988@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
When adding a movie the default path for the movie was not appropriate in all scenario's, this change ensures that the root path is used and then Radarr will name the subfolders as required. 

## Related issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here. -->
- fixes #62 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What additions does it bring? -->
Fixes an issue experienced by some users

## How has this been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of the tests you ran. -->
tested in my lab

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring.
- [x] Non-breaking change (fix or feature that wouldn't cause existing functionality to change/break).
- [ ] Breaking change (fix or feature that would cause existing functionality to change/break).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes don't generate new warnings.
- [x] I have read the [CONTRIBUTING](https://github.com/totaldebug/.github/blob/master/docs/CONTRIBUTING.md) document.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests pass.
