### PR TITLE
Make use of `params` arg in `session.get()` calls instead of manually encoding the arguments.

### DIFF
--- a/pyarr/request_api.py
+++ b/pyarr/request_api.py
@@ -42,11 +42,7 @@ class RequestAPI:
         """
         headers = {"X-Api-Key": self.api_key}
         request_url = "{url}{path}".format(url=self.host_url, path=path)
-        if len(kwargs) >= 1:
-            encoded_params = requests.utils.quote(str(kwargs))
-            request_url = "{}?{}".format(request_url, encoded_params)
-
-        res = self.session.get(request_url, headers=headers, auth=self.auth)
+        res = self.session.get(request_url, headers=headers, auth=self.auth, params=kwargs)
         return res.json()
 
     def request_post(self, path, data):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->

Improve and fixes usage of `ClientSession.get()` calls within the `RequestAPI` class

## Related issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here. -->
https://github.com/totaldebug/pyarr/issues/69

## How has this been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of the tests you ran. -->
Varified existing API calls do not break, varidabled API calls that are currently broken have been fixed ( fixes #69 )

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring.
- [x] Non-breaking change (fix or feature that wouldn't cause existing functionality to change/break).
- [ ] Breaking change (fix or feature that would cause existing functionality to change/break).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes don't generate new warnings.
- [ ] I have read the [CONTRIBUTING](https://github.com/totaldebug/.github/blob/master/docs/CONTRIBUTING.md) document.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests pass.
