### PR TITLE
SonarrAPI set_command() -> post_command()

### DIFF
--- a/pyarr/sonarr_api.py
+++ b/pyarr/sonarr_api.py
@@ -102,7 +102,7 @@ class SonarrAPI(RequestAPI):
         return res
 
     # POST /command
-    def set_command(self, name, **kwargs):
+    def post_command(self, name, **kwargs):
         """Performs any of the predetermined Sonarr command routines
 
         Note:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyarr"
-version = "2.0.2"
+version = "2.0.3"
 description = "A Sonarr and Radarr API Wrapper"
 authors = ["Steven Marks <marksie1988@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
Rename sonarr's `set_command` to `post_command` be consistent with RadarrAPI.