### PR TITLE
Sonarr Auto Folder Naming

### DIFF
--- a/pyarr/sonarr_api.py
+++ b/pyarr/sonarr_api.py
@@ -40,7 +40,7 @@ class SonarrAPI(RequestAPI):
         series_json = {
             "title": series["title"],
             "seasons": series["seasons"],
-            "path": root_dir + series["title"],
+            "rootFolderPath": root_dir,
             "qualityProfileId": quality_profile_id,
             "seasonFolder": season_folder,
             "monitored": monitored,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyarr"
-version = "2.0.5"
+version = "2.0.6"
 description = "A Sonarr and Radarr API Wrapper"
 authors = ["Steven Marks <marksie1988@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
### Changes
- Use Sonarr's internal folder naming schema

---

Currently, we're manually creating folder names for Sonarr. This is a bad idea, since it doesn't work for anyone who has customized Sonarr's folder naming schema. Additionally, the way we've been doing it does not safely handling string encoding.

So I pushed a minor change, now we'll only tell Sonarr what the root folder path should be and have it decide the rest.