### PR TITLE
fix: PUT /movie on Radarr v4

### DIFF
--- a/pyarr/radarr_api.py
+++ b/pyarr/radarr_api.py
@@ -116,7 +116,7 @@ class RadarrAPI(RequestAPI):
             JSON: 200 Ok, 401 Unauthorized
         """
 
-        path = "/api/movie"
+        path = "/api/v3/movie"
         params = {"moveFiles": move_files}
         res = self.request_put(path, data=data, params=params)
         return res

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyarr"
-version = "2.0.6"
+version = "2.0.7"
 description = "A Sonarr and Radarr API Wrapper"
 authors = ["Steven Marks <marksie1988@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
Looks like we somehow accidentally forgot to use the `/api/v3` endpoint for PUT /movie.

This PR fixes that.