### PR TITLE
fix: incorrect Radarr request queries

### DIFF
--- a/pyarr/radarr_api.py
+++ b/pyarr/radarr_api.py
@@ -582,7 +582,7 @@ class RadarrAPI(RequestAPI):
             JSON: 200 ok, 401 Unauthorized
         """
         path = f"/api/v3/indexer/{id_}"
-        res = path.request_put(path, data=data)
+        res = self.request_put(path, data=data)
         return res
 
     # DELETE /indexer/{id}
@@ -631,7 +631,7 @@ class RadarrAPI(RequestAPI):
             JSON: 200 Ok
         """
         path = f"/api/v3/downloadclient/{id_}"
-        res = path.request_put(path, data=data)
+        res = self.request_put(path, data=data)
         return res
 
     # DELETE /downloadclient/{id}
@@ -680,7 +680,7 @@ class RadarrAPI(RequestAPI):
             JSON: 200 Ok, 401 Unauthorized
         """
         path = f"/api/v3/importlist/{id_}"
-        res = path.request_put(path, data=data)
+        res = self.request_put(path, data=data)
         return res
 
     # DELETE /importlist/{id}
@@ -729,7 +729,7 @@ class RadarrAPI(RequestAPI):
             JSON: 200 Ok, 401 Unauthorized
         """
         path = f"/api/v3/notification/{id_}"
-        res = path.request_put(path, data=data)
+        res = self.request_put(path, data=data)
         return res
 
     # DELETE /notification/{id}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyarr"
-version = "2.0.6"
+version = "2.0.7"
 description = "A Sonarr and Radarr API Wrapper"
 authors = ["Steven Marks <marksie1988@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
Looks like there was a typo that got merged in.

`path.request_put` -> `self.request_put`