### PR TITLE
fix: Sonarr endpoint compatibility

### DIFF
--- a/pyarr/sonarr.py
+++ b/pyarr/sonarr.py
@@ -13,7 +13,7 @@ class SonarrAPI(BaseArrAPI):
             api_key (str): API key for Readarr
         """
 
-        ver_uri = "/v3"
+        ver_uri = ""
         super().__init__(host_url, api_key, ver_uri)
 
     def _series_json(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyarr"
-version = "3.1.0"
+version = "3.1.1"
 description = "Python client for Servarr API's (Sonarr, Radarr, Readarr)"
 authors = ["Steven Marks <marksie1988@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
Looks like you tried to use a `/v3` endpoint namespace within Sonarr when pushing out the Readarr updates...

However, the `/v3` endpoint within Sonarr is severely underdeveloped and is not suggested for production use.

This PR reverts back to the unversioned endpoint for compatibility purposes. The unversioned endpoint is the only one actively maintained by the Sonarr team.