### PR TITLE
Add undocumented MoviesSearch to post_commands

### DIFF
--- a/pyarr/models/radarr.py
+++ b/pyarr/models/radarr.py
@@ -3,6 +3,7 @@ from typing import Literal
 RadarrCommands = Literal[
     "DownloadedMoviesScan",
     "MissingMoviesSearch",
+    "MoviesSearch",
     "RefreshMovie",
     "RenameMovie",
     "RenameFiles",
@@ -22,6 +23,12 @@ DownloadedMoviesScan:
 
 MissingMoviesSearch:
     Searches for any missing movies
+
+MoviesSearch:
+    Searches for the specified movie or movies
+
+    Args:
+        movieIds (list[int]): ID of Movie or movies
 
 RefreshMovies:
     Refreshes all of the movies, or specific by ID

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyarr"
-version = "5.1.0"
+version = "5.1.1"
 description = "Synchronous Sonarr, Radarr, Lidarr and Readarr API's for Python"
 authors = ["Steven Marks <marksie1988@users.noreply.github.com>"]
 license = "MIT"

--- a/tests/test_radarr.py
+++ b/tests/test_radarr.py
@@ -38,6 +38,8 @@ def test_post_command(radarr_client: RadarrAPI):
     assert isinstance(data, dict)
     data = radarr_client.post_command(name="MissingMoviesSearch")
     assert isinstance(data, dict)
+    data = radarr_client.post_command(name="MoviesSearch")
+    assert isinstance(data, dict)
     data = radarr_client.post_command(name="DownloadedMoviesScan")
     assert isinstance(data, dict)
     data = radarr_client.post_command(name="RenameFiles", files=[1, 2, 3])


### PR DESCRIPTION

## Description
add MoviesSearch to post_commands. undocumented API that is the radarr equivalent of sonarr EpisodeSearch. It triggers a search for the given movie the same as clicking the "Search Movie" button in the UI.

## Related issues
Closes #155 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] CI / Tests update
- [ ] Documentation update

## How has this been tested
Tested in a python script on my system against a live Radarr installation. I used info from this Radarr issue https://github.com/Radarr/Radarr/issues/3315

- [x] I have added new tests where required
- [ ] I have run `nox -s tests` locally and passed
- [X] I have tested this feature in a python script

[Script used to test](https://github.com/LRomandine/servarr_upgrade_library/tree/main)
