### PR TITLE
Fix sonarr manual import method

### DIFF
--- a/pyarr/sonarr.py
+++ b/pyarr/sonarr.py
@@ -735,17 +735,17 @@ class SonarrAPI(BaseArrAPI):
 
         return self._get("manualimport", self.ver_uri, params=params)
 
-    # PUT /manualimport
-    def upd_manual_import(self, data: JsonObject) -> JsonObject:
-        """Update a manual import
+    # POST /manualimport
+    def add_manual_import(self, data: JsonArray) -> JsonArray:
+        """Add a manual import
 
         Note:
             To be used in conjunction with get_manual_import()
 
         Args:
-            data (JsonObject): Data containing changes
+            data (JsonArray): Data for the import
 
         Returns:
-            JsonObject: Dictionary of updated record
+            JsonArray: Array of dicts of the new imports
         """
-        return self._put("manualimport", self.ver_uri, data=data)
+        return self._post("manualimport", self.ver_uri, data=data)


### PR DESCRIPTION
## Description

According to Sonarr's docs (https://sonarr.tv/docs/api/#/ManualImport/post_api_v3_manualimport), this is supposed to be a POST method.

This method currently fails with 405 Method Not Allowed

## Related issues
fixes #165

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

Technically this is a breaking change, but as the method currently does not work, it will not break a current working impementation.

## How has this been tested

- [x] I have run `nox -s tests` locally and passed
