### PR TITLE
Fixes #190 by passing deleteFiles as json element, not a param

### DIFF
--- a/src/pyarr/_async/radarr/movie.py
+++ b/src/pyarr/_async/radarr/movie.py
@@ -95,16 +95,16 @@ class Movie(CommonActions):
             delete_files (bool, optional): Delete movie files. Defaults to False.
             add_exclusion (bool, optional): Add to List Exclusions. Defaults to False.
         """
-        params: dict[str, bool] = {
+        data: dict[str, bool | list[int]] = {
             "deleteFiles": delete_files,
             "addImportExclusion": add_exclusion,
         }
 
         if isinstance(item_id, list):
-            json_data = {"movieIds": item_id}
-            await self.handler.request("movie/editor", method="DELETE", json_data=json_data, params=params)
+            data["movieIds"] = item_id
+            await self.handler.request("movie/editor", method="DELETE", json_data=data)
         else:
-            await self.handler.request(f"movie/{item_id}", method="DELETE", params=params)
+            await self.handler.request(f"movie/{item_id}", method="DELETE", params=data)
 
     async def lookup(self, term: str) -> JsonArray:
         """Search for a movie to add to the database.

--- a/src/pyarr/_sync/radarr/movie.py
+++ b/src/pyarr/_sync/radarr/movie.py
@@ -100,16 +100,16 @@ class Movie(CommonActions):
             delete_files (bool, optional): Delete movie files. Defaults to False.
             add_exclusion (bool, optional): Add to List Exclusions. Defaults to False.
         """
-        params: dict[str, bool] = {
+        data: dict[str, bool | list[int]] = {
             "deleteFiles": delete_files,
             "addImportExclusion": add_exclusion,
         }
 
         if isinstance(item_id, list):
-            json_data = {"movieIds": item_id}
-            self.handler.request("movie/editor", method="DELETE", json_data=json_data, params=params)
+            data["movieIds"] = item_id
+            self.handler.request("movie/editor", method="DELETE", json_data=data)
         else:
-            self.handler.request(f"movie/{item_id}", method="DELETE", params=params)
+            self.handler.request(f"movie/{item_id}", method="DELETE", params=data)
 
     def lookup(self, term: str) -> JsonArray:
         """Search for a movie to add to the database.


### PR DESCRIPTION
## Description

<!--
Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This fixes an issue which led to `Radarr.movie.delete` failing to delete the underlying files of the movie if the first item were a list and `delete_files=True` was specified.

## Related issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here.

e.g. fixes #1, closes #2
-->

Fixes #190 

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI / Tests update
- [ ] Documentation update

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have added new tests where required
- [ ] I have run `nox -s tests` locally and passed
- [x] I have tested this feature in a python script

## Summary by Sourcery

Bug Fixes:
- Fix Radarr movie deletion so deleteFiles and exclusion options are honored for both single movie and movie list deletions by sending them in the request JSON body.