### PR TITLE
ci(sync-check): check out fork pull requests correctly

### DIFF
--- a/.github/workflows/sync-check.yaml
+++ b/.github/workflows/sync-check.yaml
@@ -19,7 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          # Fork PRs have no branch in this repository, so head_ref cannot be checked out.
+          # Use the PR merge ref for those, and keep the real branch for same-repo PRs so
+          # the auto-fix step below still has somewhere to push.
+          ref: >-
+            ${{ github.event_name != 'pull_request' && github.ref
+            || github.event.pull_request.head.repo.full_name == github.repository && github.head_ref
+            || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
           fetch-depth: 0
 
       - name: Install uv
@@ -33,6 +39,7 @@ jobs:
           python-version: "3.12"
 
       - name: Check for manual edits in _sync
+        if: github.event_name == 'pull_request'
         run: |
           # Check if any files in _sync were modified in this PR
           SYNC_MODIFIED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep "src/pyarr/_sync/" || true)
@@ -55,8 +62,10 @@ jobs:
             echo "⚠️ WARNING: Synchronous API was out of sync with asynchronous API."
           fi
 
-      - name: Auto-fix and Push (PRs only)
-        if: steps.git-check.outputs.changed == 'true' && github.event_name == 'pull_request'
+      - name: Auto-fix and Push (same-repo PRs only)
+        if: >-
+          steps.git-check.outputs.changed == 'true' && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -64,6 +73,16 @@ jobs:
           git commit -m "chore: auto-generate sync API from async changes"
           git push
           echo "✅ Successfully auto-fixed sync API parity."
+
+      - name: Fail if out of sync (fork PRs)
+        if: >-
+          steps.git-check.outputs.changed == 'true' && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "❌ ERROR: Synchronous API is out of sync with the asynchronous API."
+          echo "This PR comes from a fork, so it cannot be auto-fixed."
+          echo "Please run 'uv run python3 scripts/generate_sync.py' and commit the changes."
+          exit 1
 
       - name: Fail if out of sync (Push to main)
         if: steps.git-check.outputs.changed == 'true' && github.event_name == 'push'


### PR DESCRIPTION
## Description

`sync-check.yaml` checks out `${{ github.head_ref }}`, which can never resolve for a pull request from a fork: that branch only exists in the contributor's repository. Every fork PR that touches `src/pyarr/_async/**`, `src/pyarr/_sync/**` or `scripts/generate_sync.py` fails at the checkout step with:

```
##[error]A branch or tag with the name 'fix-movie-delete' could not be found
```

Seen on #191 ([run](https://github.com/totaldebug/pyarr/actions/runs/31761761296/job/96479888781)). The sync check never actually ran there, so the red cross says nothing about parity.

### What changed

- Fork PRs are checked out at the pull request merge ref. Same-repo PRs keep the real branch, because the auto-fix step needs somewhere to push. Push events are unchanged.
- "Auto-fix and Push" is gated to same-repo PRs. A fork PR's token is read-only and cannot push to the fork, so that step could only ever fail there.
- Fork PRs that are out of sync now fail with instructions to run `scripts/generate_sync.py` instead, since they cannot be auto-fixed.
- The "Check for manual edits in `_sync`" step is skipped on push events. `github.base_ref` is empty there, so its `git diff origin/...HEAD` was erroring into `|| true` and silently passing - a check that looked green without checking anything.

## Type of change

- [x] CI / Tests update

## How has this been tested

- [x] YAML parses and the checkout ref expression folds to a single line, evaluated for all three cases (push, same-repo PR, fork PR)
- [x] `pre-commit run --files .github/workflows/sync-check.yaml` passes, including `check-yaml`

The fork path can only be fully exercised by a fork PR against this branch once it is on `main`; #191 will be the first real check.

## Summary by Sourcery

Make the sync-check workflow correctly validate fork pull requests while preserving auto-fixes for same-repository branches.

Bug Fixes:
- Fix sync-check workflow failures for pull requests originating from forks by checking out a valid pull request ref.

Enhancements:
- Restrict automatic sync fixes to same-repository pull requests and provide fork contributors with remediation instructions when parity checks fail.
- Skip the manual `_sync` edit check on push events where pull request base metadata is unavailable.

CI:
- Update sync-check CI behavior for fork pull requests, same-repository pull requests, and push events.