### PR TITLE
test(radarr): add regression tests for movie delete request shape

### DIFF
--- a/tests/radarr/test_movie.py
+++ b/tests/radarr/test_movie.py
@@ -1,0 +1,97 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pyarr._async.radarr.movie import Movie as AsyncMovie
+from pyarr._async.utils.http import RequestHandler as AsyncRequestHandler
+from pyarr._sync.radarr.movie import Movie
+from pyarr._sync.utils.http import RequestHandler
+
+
+def test_movie_delete_single():
+    """A single ID deletes via movie/{id}, which reads the flags from the query string."""
+    mock_handler = MagicMock(spec=RequestHandler)
+    movie = Movie(mock_handler)
+
+    movie.delete(1, delete_files=True, add_exclusion=True)
+
+    mock_handler.request.assert_called_once_with(
+        "movie/1",
+        method="DELETE",
+        params={"deleteFiles": True, "addImportExclusion": True},
+    )
+
+
+def test_movie_delete_single_defaults():
+    mock_handler = MagicMock(spec=RequestHandler)
+    movie = Movie(mock_handler)
+
+    movie.delete(1)
+
+    mock_handler.request.assert_called_once_with(
+        "movie/1",
+        method="DELETE",
+        params={"deleteFiles": False, "addImportExclusion": False},
+    )
+
+
+def test_movie_delete_list_sends_flags_in_body():
+    """Regression test for #190.
+
+    movie/editor binds deleteFiles and addImportExclusion from the request body, so sending
+    them as query parameters left the movie files on disk and skipped the list exclusion.
+    """
+    mock_handler = MagicMock(spec=RequestHandler)
+    movie = Movie(mock_handler)
+
+    movie.delete([1, 2], delete_files=True, add_exclusion=True)
+
+    mock_handler.request.assert_called_once_with(
+        "movie/editor",
+        method="DELETE",
+        json_data={"deleteFiles": True, "addImportExclusion": True, "movieIds": [1, 2]},
+    )
+    assert "params" not in mock_handler.request.call_args.kwargs
+
+
+def test_movie_delete_list_defaults():
+    mock_handler = MagicMock(spec=RequestHandler)
+    movie = Movie(mock_handler)
+
+    movie.delete([1])
+
+    mock_handler.request.assert_called_once_with(
+        "movie/editor",
+        method="DELETE",
+        json_data={"deleteFiles": False, "addImportExclusion": False, "movieIds": [1]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_movie_delete_single():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    movie = AsyncMovie(mock_handler)
+
+    await movie.delete(1, delete_files=True, add_exclusion=True)
+
+    mock_handler.request.assert_called_once_with(
+        "movie/1",
+        method="DELETE",
+        params={"deleteFiles": True, "addImportExclusion": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_movie_delete_list_sends_flags_in_body():
+    """Regression test for #190, async client."""
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    movie = AsyncMovie(mock_handler)
+
+    await movie.delete([1, 2], delete_files=True, add_exclusion=True)
+
+    mock_handler.request.assert_called_once_with(
+        "movie/editor",
+        method="DELETE",
+        json_data={"deleteFiles": True, "addImportExclusion": True, "movieIds": [1, 2]},
+    )
+    assert "params" not in mock_handler.request.call_args.kwargs


### PR DESCRIPTION
## Description

Adds the missing test coverage for `Radarr.movie.delete`, which had none at all before this. Rebased onto `main` now that #191 has merged, so the diff is the single test file.

### What the test pins

Radarr's two delete endpoints bind their flags differently, which is the whole substance of #190:

- `DELETE /movie/{id}` reads `deleteFiles` / `addImportExclusion` from the **query string**
- `DELETE /movie/editor` binds them from the **request body**, alongside `movieIds`

Sending them as query params on the editor endpoint made them vanish, so files stayed on disk and the list exclusion was skipped. The test asserts the request shape on both paths, including that the list path passes no `params` at all, for the sync and the async client.

It follows the existing mock-handler convention from `tests/common/test_wanted.py`, so it needs no containers and runs anywhere.

## Related issues

Refs #190, covers the fix from #191

## Type of change

- [x] CI / Tests update

## How has this been tested

- [x] I have added new tests where required
- [x] 6 passed against this branch
- [x] Sensitivity checked in both directions: swapping in the pre-#191 `movie.py` fails exactly the 3 list-path tests, while the single-ID tests keep passing on both - they cover a path that was never broken
- [x] Coverage annotation confirms every changed line of #191 in both `movie.py` files now executes, closing the `codecov/patch` gap that PR carried
- [x] Verified end to end against a real Radarr (6.3.0.10514) in Docker before writing the test: with a file planted in the movie folder, `delete([id], delete_files=True)` left it on disk pre-fix and deleted it post-fix; `add_exclusion=True` behaved the same way

## Summary by Sourcery

Tests:
- Add synchronous and asynchronous regression coverage for Radarr movie deletion request shapes, including single-movie query parameters and bulk-deletion request bodies.