### PR TITLE
ci: require conventional pull request titles

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,37 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-title:
+    name: ✅ Conventional PR title
+    runs-on: ubuntu-latest
+    steps:
+      # Squash merges use the pull request title as the commit subject, so the
+      # title is what release-please reads to decide the next version. A title
+      # it cannot parse means the change never reaches a release.
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep in step with the changelog-sections in
+          # .github/release-please-config.json
+          types: |
+            feat
+            fix
+            perf
+            deps
+            revert
+            docs
+            chore
+            style
+            refactor
+            test
+            build
+            ci
+          requireScope: false


### PR DESCRIPTION
## Description

Adds a check that every pull request title is a conventional commit, so release-please can always classify the change.

### Why

#191 fixed a real bug and merged as `Fixes #190 by passing deleteFiles as json element, not a param`. release-please could not parse that, logged `No user facing commits found since 7f0235a - skipping`, and cut no release. The fix is on `main` but not on PyPI, and it will never appear in a changelog - the commit sits behind us in the range with no type to file it under.

Merge strategy is why the title matters: with squash merges the PR title becomes the commit subject, which is exactly what release-please reads. Enforcing the title therefore enforces the thing that actually decides releases. A local `commit-msg` hook cannot do this - #191 came from a fork.

The allowed types mirror the `changelog-sections` in `.github/release-please-config.json`, so anything this check accepts is something release-please can file. `requireScope: false` keeps `chore:` and `ci:` usable without inventing scopes.

## Type of change

- [x] CI / Tests update

## How has this been tested

- [x] Workflow YAML parses, and the type list round-trips as expected
- [x] `pre-commit run` passes on the new file, including `check-yaml`
- [x] This PR's own title is conventional, so the check should pass here - that is the first real test

## Follow-ups needed outside this repo's files

Two settings changes are needed for this to bite, which I can apply:

1. **Squash-only merging**, with the squash commit title set from the PR title. Right now merge commits are allowed, and a merge commit hides the contributor's non-conventional subject underneath it - which is exactly what happened on #191.
2. **Make this check required** in `main`'s branch protection, so a bad title blocks the merge instead of just showing a cross.

## Summary by Sourcery

Enforce release-compatible conventional pull request titles through CI.

Enhancements:
- Add a CI check that validates pull request titles against the conventional commit types recognized by release-please, without requiring scopes.

CI:
- Run the conventional pull request title check when pull requests are opened, edited, reopened, or updated.