### PR TITLE
fix(manual_import): post manual imports instead of putting them

### DIFF
--- a/src/pyarr/_async/lidarr/manual_import.py
+++ b/src/pyarr/_async/lidarr/manual_import.py
@@ -1,5 +1,5 @@
 from pyarr._async.common.base import CommonActions
-from pyarr.types import JsonArray, JsonObject
+from pyarr.types import JsonArray
 
 
 class ManualImport(CommonActions):
@@ -39,16 +39,16 @@ class ManualImport(CommonActions):
             return response
         raise ValueError("Expected a list response from the 'manualimport' endpoint")
 
-    async def update(self, data: JsonObject) -> JsonObject:
-        """Update a manual import.
+    async def update(self, data: JsonArray) -> JsonArray:
+        """Process the given manual import items.
 
         Args:
-            data (JsonObject): Data containing changes.
+            data (JsonArray): List of manual import items, as returned by get().
 
         Returns:
-            JsonObject: Dictionary of updated record.
+            JsonArray: List of dictionaries with the processed items.
         """
-        response = await self.handler.request("manualimport", method="PUT", json_data=data)
-        if isinstance(response, dict):
+        response = await self.handler.request("manualimport", method="POST", json_data=data)
+        if isinstance(response, list):
             return response
-        raise ValueError("Expected a dictionary response from the 'manualimport' endpoint")
+        raise ValueError("Expected a list response from the 'manualimport' endpoint")

--- a/src/pyarr/_async/radarr/manual_import.py
+++ b/src/pyarr/_async/radarr/manual_import.py
@@ -1,5 +1,5 @@
 from pyarr._async.common.base import CommonActions
-from pyarr.types import JsonArray, JsonObject
+from pyarr.types import JsonArray
 
 
 class ManualImport(CommonActions):
@@ -39,16 +39,16 @@ class ManualImport(CommonActions):
             return response
         raise ValueError("Expected a list response from the 'manualimport' endpoint")
 
-    async def update(self, data: JsonObject) -> JsonObject:
-        """Update a manual import.
+    async def update(self, data: JsonArray) -> JsonArray:
+        """Process the given manual import items.
 
         Args:
-            data (JsonObject): Data containing changes.
+            data (JsonArray): List of manual import items, as returned by get().
 
         Returns:
-            JsonObject: Dictionary of updated record.
+            JsonArray: List of dictionaries with the processed items.
         """
-        response = await self.handler.request("manualimport", method="PUT", json_data=data)
-        if isinstance(response, dict):
+        response = await self.handler.request("manualimport", method="POST", json_data=data)
+        if isinstance(response, list):
             return response
-        raise ValueError("Expected a dictionary response from the 'manualimport' endpoint")
+        raise ValueError("Expected a list response from the 'manualimport' endpoint")

--- a/src/pyarr/_async/readarr/manual_import.py
+++ b/src/pyarr/_async/readarr/manual_import.py
@@ -1,5 +1,5 @@
 from pyarr._async.common.base import CommonActions
-from pyarr.types import JsonArray, JsonObject
+from pyarr.types import JsonArray
 
 
 class ManualImport(CommonActions):
@@ -39,16 +39,16 @@ class ManualImport(CommonActions):
             return response
         raise ValueError("Expected a list response from the 'manualimport' endpoint")
 
-    async def update(self, data: JsonObject) -> JsonObject:
-        """Update a manual import.
+    async def update(self, data: JsonArray) -> JsonArray:
+        """Process the given manual import items.
 
         Args:
-            data (JsonObject): Data containing changes.
+            data (JsonArray): List of manual import items, as returned by get().
 
         Returns:
-            JsonObject: Dictionary of updated record.
+            JsonArray: List of dictionaries with the processed items.
         """
-        response = await self.handler.request("manualimport", method="PUT", json_data=data)
-        if isinstance(response, dict):
+        response = await self.handler.request("manualimport", method="POST", json_data=data)
+        if isinstance(response, list):
             return response
-        raise ValueError("Expected a dictionary response from the 'manualimport' endpoint")
+        raise ValueError("Expected a list response from the 'manualimport' endpoint")

--- a/src/pyarr/_async/sonarr/manual_import.py
+++ b/src/pyarr/_async/sonarr/manual_import.py
@@ -1,5 +1,5 @@
 from pyarr._async.common.base import CommonActions
-from pyarr.types import JsonArray, JsonObject
+from pyarr.types import JsonArray
 
 
 class ManualImport(CommonActions):
@@ -39,16 +39,16 @@ class ManualImport(CommonActions):
             return response
         raise ValueError("Expected a list response from the 'manualimport' endpoint")
 
-    async def update(self, data: JsonObject) -> JsonObject:
-        """Update a manual import.
+    async def update(self, data: JsonArray) -> JsonArray:
+        """Process the given manual import items.
 
         Args:
-            data (JsonObject): Data containing changes.
+            data (JsonArray): List of manual import items, as returned by get().
 
         Returns:
-            JsonObject: Dictionary of updated record.
+            JsonArray: List of dictionaries with the processed items.
         """
-        response = await self.handler.request("manualimport", method="PUT", json_data=data)
-        if isinstance(response, dict):
+        response = await self.handler.request("manualimport", method="POST", json_data=data)
+        if isinstance(response, list):
             return response
-        raise ValueError("Expected a dictionary response from the 'manualimport' endpoint")
+        raise ValueError("Expected a list response from the 'manualimport' endpoint")

--- a/src/pyarr/_async/utils/http.py
+++ b/src/pyarr/_async/utils/http.py
@@ -143,7 +143,7 @@ class RequestHandler:
         endpoint: str,
         method: str = "GET",
         data: Any = None,
-        json_data: dict[str, Any] | None = None,
+        json_data: dict[str, Any] | list[Any] | None = None,
         params: Mapping[str, Any] | None = None,
         headers: dict | None = None,
     ) -> Any:
@@ -153,7 +153,8 @@ class RequestHandler:
             endpoint (str): The endpoint to send the request to.
             method (str, optional): The HTTP method to use. Defaults to "GET".
             data (Any, optional): The data to send in the request body. Defaults to None.
-            json_data (dict[str, Any] | None, optional): The JSON data to send in the request body. Defaults to None.
+            json_data (dict[str, Any] | list[Any] | None, optional): The JSON data to send in the request body.
+                Some endpoints, such as manualimport, take a JSON array. Defaults to None.
             params (Mapping[str, Any] | None, optional): The parameters to include in the request URL. Defaults to None.
             headers (Optional[dict], optional): The headers to include in the request. Defaults to None.
 

--- a/src/pyarr/_sync/lidarr/manual_import.py
+++ b/src/pyarr/_sync/lidarr/manual_import.py
@@ -4,7 +4,7 @@
 # """
 
 from pyarr._sync.common.base import CommonActions
-from pyarr.types import JsonArray, JsonObject
+from pyarr.types import JsonArray
 
 
 class ManualImport(CommonActions):
@@ -44,16 +44,16 @@ class ManualImport(CommonActions):
             return response
         raise ValueError("Expected a list response from the 'manualimport' endpoint")
 
-    def update(self, data: JsonObject) -> JsonObject:
-        """Update a manual import.
+    def update(self, data: JsonArray) -> JsonArray:
+        """Process the given manual import items.
 
         Args:
-            data (JsonObject): Data containing changes.
+            data (JsonArray): List of manual import items, as returned by get().
 
         Returns:
-            JsonObject: Dictionary of updated record.
+            JsonArray: List of dictionaries with the processed items.
         """
-        response = self.handler.request("manualimport", method="PUT", json_data=data)
-        if isinstance(response, dict):
+        response = self.handler.request("manualimport", method="POST", json_data=data)
+        if isinstance(response, list):
             return response
-        raise ValueError("Expected a dictionary response from the 'manualimport' endpoint")
+        raise ValueError("Expected a list response from the 'manualimport' endpoint")

--- a/src/pyarr/_sync/radarr/manual_import.py
+++ b/src/pyarr/_sync/radarr/manual_import.py
@@ -4,7 +4,7 @@
 # """
 
 from pyarr._sync.common.base import CommonActions
-from pyarr.types import JsonArray, JsonObject
+from pyarr.types import JsonArray
 
 
 class ManualImport(CommonActions):
@@ -44,16 +44,16 @@ class ManualImport(CommonActions):
             return response
         raise ValueError("Expected a list response from the 'manualimport' endpoint")
 
-    def update(self, data: JsonObject) -> JsonObject:
-        """Update a manual import.
+    def update(self, data: JsonArray) -> JsonArray:
+        """Process the given manual import items.
 
         Args:
-            data (JsonObject): Data containing changes.
+            data (JsonArray): List of manual import items, as returned by get().
 
         Returns:
-            JsonObject: Dictionary of updated record.
+            JsonArray: List of dictionaries with the processed items.
         """
-        response = self.handler.request("manualimport", method="PUT", json_data=data)
-        if isinstance(response, dict):
+        response = self.handler.request("manualimport", method="POST", json_data=data)
+        if isinstance(response, list):
             return response
-        raise ValueError("Expected a dictionary response from the 'manualimport' endpoint")
+        raise ValueError("Expected a list response from the 'manualimport' endpoint")

--- a/src/pyarr/_sync/readarr/manual_import.py
+++ b/src/pyarr/_sync/readarr/manual_import.py
@@ -4,7 +4,7 @@
 # """
 
 from pyarr._sync.common.base import CommonActions
-from pyarr.types import JsonArray, JsonObject
+from pyarr.types import JsonArray
 
 
 class ManualImport(CommonActions):
@@ -44,16 +44,16 @@ class ManualImport(CommonActions):
             return response
         raise ValueError("Expected a list response from the 'manualimport' endpoint")
 
-    def update(self, data: JsonObject) -> JsonObject:
-        """Update a manual import.
+    def update(self, data: JsonArray) -> JsonArray:
+        """Process the given manual import items.
 
         Args:
-            data (JsonObject): Data containing changes.
+            data (JsonArray): List of manual import items, as returned by get().
 
         Returns:
-            JsonObject: Dictionary of updated record.
+            JsonArray: List of dictionaries with the processed items.
         """
-        response = self.handler.request("manualimport", method="PUT", json_data=data)
-        if isinstance(response, dict):
+        response = self.handler.request("manualimport", method="POST", json_data=data)
+        if isinstance(response, list):
             return response
-        raise ValueError("Expected a dictionary response from the 'manualimport' endpoint")
+        raise ValueError("Expected a list response from the 'manualimport' endpoint")

--- a/src/pyarr/_sync/sonarr/manual_import.py
+++ b/src/pyarr/_sync/sonarr/manual_import.py
@@ -4,7 +4,7 @@
 # """
 
 from pyarr._sync.common.base import CommonActions
-from pyarr.types import JsonArray, JsonObject
+from pyarr.types import JsonArray
 
 
 class ManualImport(CommonActions):
@@ -44,16 +44,16 @@ class ManualImport(CommonActions):
             return response
         raise ValueError("Expected a list response from the 'manualimport' endpoint")
 
-    def update(self, data: JsonObject) -> JsonObject:
-        """Update a manual import.
+    def update(self, data: JsonArray) -> JsonArray:
+        """Process the given manual import items.
 
         Args:
-            data (JsonObject): Data containing changes.
+            data (JsonArray): List of manual import items, as returned by get().
 
         Returns:
-            JsonObject: Dictionary of updated record.
+            JsonArray: List of dictionaries with the processed items.
         """
-        response = self.handler.request("manualimport", method="PUT", json_data=data)
-        if isinstance(response, dict):
+        response = self.handler.request("manualimport", method="POST", json_data=data)
+        if isinstance(response, list):
             return response
-        raise ValueError("Expected a dictionary response from the 'manualimport' endpoint")
+        raise ValueError("Expected a list response from the 'manualimport' endpoint")

--- a/src/pyarr/_sync/utils/http.py
+++ b/src/pyarr/_sync/utils/http.py
@@ -148,7 +148,7 @@ class RequestHandler:
         endpoint: str,
         method: str = "GET",
         data: Any = None,
-        json_data: dict[str, Any] | None = None,
+        json_data: dict[str, Any] | list[Any] | None = None,
         params: Mapping[str, Any] | None = None,
         headers: dict | None = None,
     ) -> Any:
@@ -158,7 +158,8 @@ class RequestHandler:
             endpoint (str): The endpoint to send the request to.
             method (str, optional): The HTTP method to use. Defaults to "GET".
             data (Any, optional): The data to send in the request body. Defaults to None.
-            json_data (dict[str, Any] | None, optional): The JSON data to send in the request body. Defaults to None.
+            json_data (dict[str, Any] | list[Any] | None, optional): The JSON data to send in the request body.
+                Some endpoints, such as manualimport, take a JSON array. Defaults to None.
             params (Mapping[str, Any] | None, optional): The parameters to include in the request URL. Defaults to None.
             headers (Optional[dict], optional): The headers to include in the request. Defaults to None.
 

--- a/tests/common/test_manual_import.py
+++ b/tests/common/test_manual_import.py
@@ -61,3 +61,14 @@ async def test_async_manual_import_update_posts_a_list(manual_import_class):
     assert await manual_import.update(items) == []
 
     mock_handler.request.assert_called_once_with("manualimport", method="POST", json_data=items)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manual_import_class", ASYNC_CLASSES)
+async def test_async_manual_import_update_rejects_non_list_response(manual_import_class):
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    mock_handler.request.return_value = {"message": "not a list"}
+    manual_import = manual_import_class(mock_handler)
+
+    with pytest.raises(ValueError, match="Expected a list response"):
+        await manual_import.update([])

--- a/tests/common/test_manual_import.py
+++ b/tests/common/test_manual_import.py
@@ -1,0 +1,63 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pyarr._async.lidarr.manual_import import ManualImport as AsyncLidarrManualImport
+from pyarr._async.radarr.manual_import import ManualImport as AsyncRadarrManualImport
+from pyarr._async.readarr.manual_import import ManualImport as AsyncReadarrManualImport
+from pyarr._async.sonarr.manual_import import ManualImport as AsyncSonarrManualImport
+from pyarr._async.utils.http import RequestHandler as AsyncRequestHandler
+from pyarr._sync.lidarr.manual_import import ManualImport as LidarrManualImport
+from pyarr._sync.radarr.manual_import import ManualImport as RadarrManualImport
+from pyarr._sync.readarr.manual_import import ManualImport as ReadarrManualImport
+from pyarr._sync.sonarr.manual_import import ManualImport as SonarrManualImport
+from pyarr._sync.utils.http import RequestHandler
+
+SYNC_CLASSES = [SonarrManualImport, RadarrManualImport, LidarrManualImport, ReadarrManualImport]
+ASYNC_CLASSES = [
+    AsyncSonarrManualImport,
+    AsyncRadarrManualImport,
+    AsyncLidarrManualImport,
+    AsyncReadarrManualImport,
+]
+
+
+@pytest.mark.parametrize("manual_import_class", SYNC_CLASSES)
+def test_manual_import_update_posts_a_list(manual_import_class):
+    """Regression test for #165.
+
+    manualimport only accepts POST - a PUT is answered with 405 Method Not Allowed - and it
+    takes and returns a JSON array rather than a single object.
+    """
+    mock_handler = MagicMock(spec=RequestHandler)
+    mock_handler.request.return_value = []
+    manual_import = manual_import_class(mock_handler)
+
+    items = [{"path": "/downloads/a.mkv", "seriesId": 1}]
+    assert manual_import.update(items) == []
+
+    mock_handler.request.assert_called_once_with("manualimport", method="POST", json_data=items)
+
+
+@pytest.mark.parametrize("manual_import_class", SYNC_CLASSES)
+def test_manual_import_update_rejects_non_list_response(manual_import_class):
+    mock_handler = MagicMock(spec=RequestHandler)
+    mock_handler.request.return_value = {"message": "not a list"}
+    manual_import = manual_import_class(mock_handler)
+
+    with pytest.raises(ValueError, match="Expected a list response"):
+        manual_import.update([])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manual_import_class", ASYNC_CLASSES)
+async def test_async_manual_import_update_posts_a_list(manual_import_class):
+    """Regression test for #165, async client."""
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    mock_handler.request.return_value = []
+    manual_import = manual_import_class(mock_handler)
+
+    items = [{"path": "/downloads/a.mkv", "movieId": 1}]
+    assert await manual_import.update(items) == []
+
+    mock_handler.request.assert_called_once_with("manualimport", method="POST", json_data=items)

--- a/tests/common/test_request_handler.py
+++ b/tests/common/test_request_handler.py
@@ -1,0 +1,42 @@
+import json
+
+import httpx
+import pytest
+
+from pyarr._async.utils.http import RequestHandler as AsyncRequestHandler
+from pyarr._sync.utils.http import RequestHandler
+
+
+def _transport(captured):
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["content"] = request.content
+        return httpx.Response(200, json=[], headers={"Content-Type": "application/json"})
+
+    return handler
+
+
+def test_request_sends_list_json_data():
+    """A list json_data must reach the wire as a JSON array, not be coerced to an object."""
+    captured: dict[str, object] = {}
+    session = httpx.Client(transport=httpx.MockTransport(_transport(captured)))
+    handler = RequestHandler(host="localhost", api_key="key", port=8989, tls=False, api_ver="v3", session=session)
+
+    payload = [{"path": "/downloads/a.mkv", "seriesId": 1}]
+    assert handler.request("manualimport", method="POST", json_data=payload) == []
+
+    assert captured["method"] == "POST"
+    assert json.loads(captured["content"]) == payload
+
+
+@pytest.mark.asyncio
+async def test_async_request_sends_list_json_data():
+    captured: dict[str, object] = {}
+    session = httpx.AsyncClient(transport=httpx.MockTransport(_transport(captured)))
+    handler = AsyncRequestHandler(host="localhost", api_key="key", port=8989, tls=False, api_ver="v3", session=session)
+
+    payload = [{"path": "/downloads/a.mkv", "movieId": 1}]
+    assert await handler.request("manualimport", method="POST", json_data=payload) == []
+
+    assert captured["method"] == "POST"
+    assert json.loads(captured["content"]) == payload


### PR DESCRIPTION
## Description

`manual_import.update()` sends `PUT /api/v3/manualimport`, which the *arr APIs answer with **405 Method Not Allowed**. The method could never succeed on any client. The endpoint is `POST`, and it takes and returns a JSON array rather than a single object.

Verified by probing live containers:

| | PUT | POST |
|---|---|---|
| Sonarr 4.0.19.2979 | `405` | `200` |
| Radarr 6.3.0.10514 | `405` | `400` (empty body rejected, so the route exists) |

### What changed

- `update()` now posts, and its signature moves from `JsonObject` to `JsonArray` in and out, matching what the endpoint actually takes. It pairs with `get()`, which already returns a `JsonArray` - the output of `get()` can now be handed straight to `update()`, which is how the reporter expected to use it.
- Fixed in all four clients that expose it: Sonarr, Radarr, Lidarr, Readarr. They each carried an identical copy of the broken method.
- `RequestHandler.request`'s `json_data` widens from `dict[str, Any] | None` to `dict[str, Any] | list[Any] | None`, since this is the first endpoint that needs an array body. It was already passed straight to httpx's `json=`, so no behaviour change.

The signature change is technically breaking, but only for a call that raised `PyarrMethodNotAllowed` 100% of the time, so no working code can depend on it.

## Related issues

Fixes #165

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] I have added new tests where required - 12 tests across the four clients, sync and async, asserting the method and array payload
- [x] Reproduced end to end against a live Sonarr first: `manual_import.update([])` raised `PyarrMethodNotAllowed` before the change and returns `[]` after it
- [x] `pre-commit run --all-files` passes, including sync/async parity and mypy

## Summary by Sourcery

Fix manual import processing so clients can submit and receive endpoint-compatible item lists.

Bug Fixes:
- Fix manual import processing across Sonarr, Radarr, Lidarr, and Readarr by using the supported POST endpoint and accepting and returning JSON arrays.

Enhancements:
- Allow request handlers to send JSON array payloads for endpoints that require them.

Tests:
- Add synchronous and asynchronous regression coverage for manual import requests, response validation, and array JSON serialization.