### PR TITLE
feat(indexer): support forceSave when updating indexers

### DIFF
--- a/src/pyarr/_async/common/indexer.py
+++ b/src/pyarr/_async/common/indexer.py
@@ -33,17 +33,20 @@ class Indexer(CommonActions):
             return [item for item in response if item["implementation"] == implementation]
         return response
 
-    async def update(self, item_id: int, data: JsonObject) -> JsonObject:
+    async def update(self, item_id: int, data: JsonObject, force_save: bool = False) -> JsonObject:
         """Edit an indexer by database id.
 
         Args:
             item_id (int): Indexer database id.
             data (JsonObject): Data to be updated within indexer.
+            force_save (bool, optional): Save the indexer even when validation raises warnings,
+                for example setting the minimum number of seeders to 0. Defaults to False.
 
         Returns:
             JsonObject: Dictionary of updated record.
         """
-        response = await self.handler.request(f"indexer/{item_id}", method="PUT", json_data=data)
+        params: dict[str, bool] = {"forceSave": force_save}
+        response = await self.handler.request(f"indexer/{item_id}", method="PUT", json_data=data, params=params)
         if isinstance(response, dict):
             return response
         raise ValueError(f"Expected a dictionary response from the 'indexer/{item_id}' endpoint")

--- a/src/pyarr/_sync/common/indexer.py
+++ b/src/pyarr/_sync/common/indexer.py
@@ -38,17 +38,20 @@ class Indexer(CommonActions):
             return [item for item in response if item["implementation"] == implementation]
         return response
 
-    def update(self, item_id: int, data: JsonObject) -> JsonObject:
+    def update(self, item_id: int, data: JsonObject, force_save: bool = False) -> JsonObject:
         """Edit an indexer by database id.
 
         Args:
             item_id (int): Indexer database id.
             data (JsonObject): Data to be updated within indexer.
+            force_save (bool, optional): Save the indexer even when validation raises warnings,
+                for example setting the minimum number of seeders to 0. Defaults to False.
 
         Returns:
             JsonObject: Dictionary of updated record.
         """
-        response = self.handler.request(f"indexer/{item_id}", method="PUT", json_data=data)
+        params: dict[str, bool] = {"forceSave": force_save}
+        response = self.handler.request(f"indexer/{item_id}", method="PUT", json_data=data, params=params)
         if isinstance(response, dict):
             return response
         raise ValueError(f"Expected a dictionary response from the 'indexer/{item_id}' endpoint")

--- a/tests/common/test_indexer.py
+++ b/tests/common/test_indexer.py
@@ -1,0 +1,98 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pyarr._async.common.indexer import Indexer as AsyncCommonIndexer
+from pyarr._async.prowlarr.indexer import Indexer as AsyncProwlarrIndexer
+from pyarr._async.utils.http import RequestHandler as AsyncRequestHandler
+from pyarr._sync.common.indexer import Indexer as CommonIndexer
+from pyarr._sync.prowlarr.indexer import Indexer as ProwlarrIndexer
+from pyarr._sync.utils.http import RequestHandler
+
+SYNC_CLASSES = [CommonIndexer, ProwlarrIndexer]
+ASYNC_CLASSES = [AsyncCommonIndexer, AsyncProwlarrIndexer]
+
+INDEXER = {"id": 1, "name": "Test", "fields": [{"name": "minimumSeeders", "value": 0}]}
+
+
+@pytest.mark.parametrize("indexer_class", SYNC_CLASSES)
+def test_indexer_update_defaults_to_unforced(indexer_class):
+    """forceSave is sent as a query parameter and defaults to the API default of false."""
+    mock_handler = MagicMock(spec=RequestHandler)
+    mock_handler.request.return_value = INDEXER
+    indexer = indexer_class(mock_handler)
+
+    assert indexer.update(1, INDEXER) == INDEXER
+
+    mock_handler.request.assert_called_once_with(
+        "indexer/1", method="PUT", json_data=INDEXER, params={"forceSave": False}
+    )
+
+
+@pytest.mark.parametrize("indexer_class", SYNC_CLASSES)
+def test_indexer_update_can_force_save(indexer_class):
+    """Regression test for #169.
+
+    Some configurations, such as a minimum seeders of 0, raise a validation warning that the
+    API refuses to save unless forceSave=true is passed.
+    """
+    mock_handler = MagicMock(spec=RequestHandler)
+    mock_handler.request.return_value = INDEXER
+    indexer = indexer_class(mock_handler)
+
+    assert indexer.update(1, INDEXER, force_save=True) == INDEXER
+
+    mock_handler.request.assert_called_once_with(
+        "indexer/1", method="PUT", json_data=INDEXER, params={"forceSave": True}
+    )
+
+
+@pytest.mark.parametrize("indexer_class", SYNC_CLASSES)
+def test_indexer_update_rejects_non_dict_response(indexer_class):
+    mock_handler = MagicMock(spec=RequestHandler)
+    mock_handler.request.return_value = []
+    indexer = indexer_class(mock_handler)
+
+    with pytest.raises(ValueError, match="Expected a dictionary response"):
+        indexer.update(1, INDEXER)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("indexer_class", ASYNC_CLASSES)
+async def test_async_indexer_update_defaults_to_unforced(indexer_class):
+    """forceSave is sent as a query parameter and defaults to the API default of false."""
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    mock_handler.request.return_value = INDEXER
+    indexer = indexer_class(mock_handler)
+
+    assert await indexer.update(1, INDEXER) == INDEXER
+
+    mock_handler.request.assert_called_once_with(
+        "indexer/1", method="PUT", json_data=INDEXER, params={"forceSave": False}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("indexer_class", ASYNC_CLASSES)
+async def test_async_indexer_update_can_force_save(indexer_class):
+    """Regression test for #169, async client."""
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    mock_handler.request.return_value = INDEXER
+    indexer = indexer_class(mock_handler)
+
+    assert await indexer.update(1, INDEXER, force_save=True) == INDEXER
+
+    mock_handler.request.assert_called_once_with(
+        "indexer/1", method="PUT", json_data=INDEXER, params={"forceSave": True}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("indexer_class", ASYNC_CLASSES)
+async def test_async_indexer_update_rejects_non_dict_response(indexer_class):
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    mock_handler.request.return_value = []
+    indexer = indexer_class(mock_handler)
+
+    with pytest.raises(ValueError, match="Expected a dictionary response"):
+        await indexer.update(1, INDEXER)


### PR DESCRIPTION
## Description

`indexer.update()` had no way to pass the `forceSave` query parameter that `PUT /api/v3/indexer/{id}` accepts.
Without it, any configuration that trips a validation *warning* is rejected with a 400 and cannot be saved through the API at all, even though the web UI lets you acknowledge the warning and save anyway.

`update()` now takes `force_save: bool = False`, sent as the `forceSave` query parameter.
The file lives in `src/pyarr/_async/common/indexer.py`, so this covers Sonarr, Radarr, Lidarr, Readarr and Prowlarr in one change.

```python
sonarr.indexer.update(indexer_id, indexer, force_save=True)
```

**On the query-parameter pattern:** the repo has two conventions - always send the parameter (`radarr/movie.py` `delete`) and only send it when it is not `None` (`common/queue.py` `delete`).
The conditional pattern exists for tri-state optionals where "unset" is meaningfully different from `False`.
`forceSave` is not one of those: it is a plain `bool` whose API default is `false`, so `forceSave=false` and omitting it are identical to the server.
Always sending it therefore keeps the signature honest (`bool`, not `bool | None`), keeps the method body to one line, and matches `radarr/movie.py` `delete`, which is the closest existing analogue.

Scope is deliberately limited to `indexer.update` to keep the diff reviewable.

## Related issues

Fixes #169

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] I have added new tests where required
- [x] I have run the test suite locally and passed
- [x] I have tested this feature in a python script

**Unit tests** - `tests/common/test_indexer.py`, 12 cases across the sync and async clients and the common and Prowlarr `Indexer` classes.
They assert the request shape for the default (unforced) call, `params={"forceSave": False}`, and for the forced call, `params={"forceSave": True}`.

**Live verification** against `lscr.io/linuxserver/sonarr:latest`, driven through the pyarr client (both sync and async), with a Torznab indexer pointed at a small local fake Torznab endpoint so the connectivity test passes:

| call | result |
| --- | --- |
| `update(1, indexer)` with `seedCriteria.seedRatio = 1.5` | saved (202) |
| `update(1, indexer)` with `seedCriteria.seedRatio = 0` | rejected, `PyarrBadRequest` (400, `isWarning: true`, "Should be greater than zero") |
| `update(1, indexer, force_save=True)` with the same `seedCriteria.seedRatio = 0` body | saved (202), value persisted as `0` |

Identical request bodies; only the query parameter differs.
That confirms Sonarr genuinely honours the parameter rather than ignoring it, and that the default call behaves exactly as it does today.

One note on the issue's specific example: current Sonarr accepts `minimumSeeders = 0` on a Torznab indexer without any warning, so that exact value could not be made to reproduce the rejection on this version.
The seed-ratio warning above exercises the same code path (`forceSave` suppressing validation warnings) and is what was verified end to end.

Non-integration suite: 26 pre-existing failures, unchanged from `main` (they need the docker containers on the default ports); passing tests go from 29 to 41 with the new cases.

## Summary by Sourcery

Support forcing indexer updates through the API while preserving the existing default behavior.

New Features:
- Add an optional `force_save` argument to synchronous and asynchronous indexer updates, allowing configurations with validation warnings to be saved.

Bug Fixes:
- Allow indexer updates that previously failed because the API rejected warning-level validation results.

Tests:
- Add synchronous and asynchronous coverage for default and forced indexer updates across common and Prowlarr clients, including response validation.