### PR TITLE
feat(series): add bulk series editor support

### DIFF
--- a/docs/MISSING_ENDPOINTS.md
+++ b/docs/MISSING_ENDPOINTS.md
@@ -23,7 +23,6 @@ The following endpoints are available in most services but may not be fully expo
 ## Sonarr Specific
 
 - **Series & Episodes**:
-  - `PUT /api/v3/series/editor`: Bulk update multiple series.
   - `POST /api/v3/series/import`: Bulk import series from a path.
   - `POST /api/v3/episode/monitor`: Bulk update episode monitored status.
   - `POST /api/v3/episode/search`: Trigger search for specific episodes.

--- a/src/pyarr/_async/sonarr/series.py
+++ b/src/pyarr/_async/sonarr/series.py
@@ -95,17 +95,47 @@ class Series(CommonActions):
             return response
         raise ValueError("Expected a dictionary response from the 'series' endpoint")
 
-    async def delete(self, item_id: int, delete_files: bool = False) -> bool:
-        """Delete a series from the database.
+    async def bulk_update(self, data: JsonObject) -> JsonArray:
+        """Bulk update multiple series in the database.
 
         Args:
-            item_id (int): series id.
-            delete_files (bool, optional): Also delete files associated with the series. Defaults to False.
+            data (JsonObject): Dictionary containing a `seriesIds` list of the series to change, along with
+                the fields to apply to them, e.g. `{"seriesIds": [1, 2], "monitored": False}`.
 
         Returns:
-            bool: True if series was deleted.
+            JsonArray: List of dictionaries with the updated records.
         """
-        await self.handler.request(f"series/{item_id}", method="DELETE", params={"deleteFiles": delete_files})
+        response = await self.handler.request("series/editor", method="PUT", json_data=data)
+        if isinstance(response, list):
+            return response
+        raise ValueError("Expected a list response from the 'series/editor' endpoint")
+
+    async def delete(
+        self,
+        item_id: int | list[int],
+        delete_files: bool = False,
+        add_exclusion: bool = False,
+    ) -> bool:
+        """Delete a single series or multiple series from the database.
+
+        Args:
+            item_id (int | list[int]): Single series ID or list of series IDs to delete.
+            delete_files (bool, optional): Also delete files associated with the series. Defaults to False.
+            add_exclusion (bool, optional): Add the series to the import list exclusions. Defaults to False.
+
+        Returns:
+            bool: True if the series were deleted.
+        """
+        data: dict[str, bool | list[int]] = {
+            "deleteFiles": delete_files,
+            "addImportListExclusion": add_exclusion,
+        }
+
+        if isinstance(item_id, list):
+            data["seriesIds"] = item_id
+            await self.handler.request("series/editor", method="DELETE", json_data=data)
+        else:
+            await self.handler.request(f"series/{item_id}", method="DELETE", params=data)
         return True
 
     async def lookup(self, term: str | None = None, item_id: int | None = None) -> JsonArray:

--- a/src/pyarr/_sync/sonarr/series.py
+++ b/src/pyarr/_sync/sonarr/series.py
@@ -100,17 +100,47 @@ class Series(CommonActions):
             return response
         raise ValueError("Expected a dictionary response from the 'series' endpoint")
 
-    def delete(self, item_id: int, delete_files: bool = False) -> bool:
-        """Delete a series from the database.
+    def bulk_update(self, data: JsonObject) -> JsonArray:
+        """Bulk update multiple series in the database.
 
         Args:
-            item_id (int): series id.
-            delete_files (bool, optional): Also delete files associated with the series. Defaults to False.
+            data (JsonObject): Dictionary containing a `seriesIds` list of the series to change, along with
+                the fields to apply to them, e.g. `{"seriesIds": [1, 2], "monitored": False}`.
 
         Returns:
-            bool: True if series was deleted.
+            JsonArray: List of dictionaries with the updated records.
         """
-        self.handler.request(f"series/{item_id}", method="DELETE", params={"deleteFiles": delete_files})
+        response = self.handler.request("series/editor", method="PUT", json_data=data)
+        if isinstance(response, list):
+            return response
+        raise ValueError("Expected a list response from the 'series/editor' endpoint")
+
+    def delete(
+        self,
+        item_id: int | list[int],
+        delete_files: bool = False,
+        add_exclusion: bool = False,
+    ) -> bool:
+        """Delete a single series or multiple series from the database.
+
+        Args:
+            item_id (int | list[int]): Single series ID or list of series IDs to delete.
+            delete_files (bool, optional): Also delete files associated with the series. Defaults to False.
+            add_exclusion (bool, optional): Add the series to the import list exclusions. Defaults to False.
+
+        Returns:
+            bool: True if the series were deleted.
+        """
+        data: dict[str, bool | list[int]] = {
+            "deleteFiles": delete_files,
+            "addImportListExclusion": add_exclusion,
+        }
+
+        if isinstance(item_id, list):
+            data["seriesIds"] = item_id
+            self.handler.request("series/editor", method="DELETE", json_data=data)
+        else:
+            self.handler.request(f"series/{item_id}", method="DELETE", params=data)
         return True
 
     def lookup(self, term: str | None = None, item_id: int | None = None) -> JsonArray:

--- a/tests/integration/test_sonarr_series.py
+++ b/tests/integration/test_sonarr_series.py
@@ -61,3 +61,47 @@ def test_sonarr_series_add_update_delete(sonarr_client: Sonarr):
 
     # Delete series
     assert sonarr_client.series.delete(item_id=series_id) is True
+
+
+def test_sonarr_series_bulk_update_and_bulk_delete(sonarr_client: Sonarr):
+    root_folders = sonarr_client.root_folder.get()
+    if not root_folders:
+        sonarr_client.root_folder.add(path="/config")
+        root_folders = sonarr_client.root_folder.get()
+    assert isinstance(root_folders, list)
+
+    # The Simpsons (71663) and Futurama (73871)
+    tvdb_ids = [71663, 73871]
+
+    # Remove any existing copies so the add below always succeeds
+    all_series = sonarr_client.series.get()
+    assert isinstance(all_series, list)
+    existing = [s["id"] for s in all_series if s["tvdbId"] in tvdb_ids]
+    if existing:
+        sonarr_client.series.delete(item_id=existing)
+
+    series_ids = []
+    for tvdb_id in tvdb_ids:
+        lookup = sonarr_client.series.lookup(item_id=tvdb_id)
+        assert len(lookup) > 0
+        added = sonarr_client.series.add(
+            series=lookup[0],
+            quality_profile_id=1,
+            language_profile_id=1,
+            root_dir=root_folders[0]["path"],
+            monitored=False,
+        )
+        series_ids.append(added["id"])
+
+    # Bulk update both series in a single request
+    updated = sonarr_client.series.bulk_update(data={"seriesIds": series_ids, "monitored": True})
+    assert isinstance(updated, list)
+    assert {s["id"] for s in updated} == set(series_ids)
+    assert all(s["monitored"] is True for s in updated)
+
+    # Bulk delete both series in a single request
+    assert sonarr_client.series.delete(item_id=series_ids, delete_files=True) is True
+
+    remaining = sonarr_client.series.get()
+    assert isinstance(remaining, list)
+    assert not [s for s in remaining if s["id"] in series_ids]

--- a/tests/sonarr/test_series.py
+++ b/tests/sonarr/test_series.py
@@ -1,0 +1,138 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pyarr._async.sonarr.series import Series as AsyncSeries
+from pyarr._async.utils.http import RequestHandler as AsyncRequestHandler
+from pyarr._sync.sonarr.series import Series
+from pyarr._sync.utils.http import RequestHandler
+
+
+def test_series_delete_single():
+    """A single ID deletes via series/{id}, which reads the flags from the query string."""
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    assert series.delete(1, delete_files=True, add_exclusion=True) is True
+
+    mock_handler.request.assert_called_once_with(
+        "series/1",
+        method="DELETE",
+        params={"deleteFiles": True, "addImportListExclusion": True},
+    )
+
+
+def test_series_delete_single_defaults():
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    assert series.delete(1) is True
+
+    mock_handler.request.assert_called_once_with(
+        "series/1",
+        method="DELETE",
+        params={"deleteFiles": False, "addImportListExclusion": False},
+    )
+
+
+def test_series_delete_list_sends_flags_in_body():
+    """Regression guard modelled on #190.
+
+    series/editor binds deleteFiles and addImportListExclusion from the request body, so sending
+    them as query parameters leaves the series files on disk and skips the list exclusion.
+    """
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    assert series.delete([1, 2], delete_files=True, add_exclusion=True) is True
+
+    mock_handler.request.assert_called_once_with(
+        "series/editor",
+        method="DELETE",
+        json_data={"deleteFiles": True, "addImportListExclusion": True, "seriesIds": [1, 2]},
+    )
+    assert "params" not in mock_handler.request.call_args.kwargs
+
+
+def test_series_delete_list_defaults():
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    assert series.delete([1]) is True
+
+    mock_handler.request.assert_called_once_with(
+        "series/editor",
+        method="DELETE",
+        json_data={"deleteFiles": False, "addImportListExclusion": False, "seriesIds": [1]},
+    )
+    assert "params" not in mock_handler.request.call_args.kwargs
+
+
+def test_series_bulk_update():
+    mock_handler = MagicMock(spec=RequestHandler)
+    mock_handler.request.return_value = [{"id": 1, "monitored": True}, {"id": 2, "monitored": True}]
+    series = Series(mock_handler)
+
+    result = series.bulk_update({"seriesIds": [1, 2], "monitored": True})
+
+    mock_handler.request.assert_called_once_with(
+        "series/editor",
+        method="PUT",
+        json_data={"seriesIds": [1, 2], "monitored": True},
+    )
+    assert result == [{"id": 1, "monitored": True}, {"id": 2, "monitored": True}]
+
+
+def test_series_bulk_update_unexpected_response():
+    mock_handler = MagicMock(spec=RequestHandler)
+    mock_handler.request.return_value = {"message": "nope"}
+    series = Series(mock_handler)
+
+    with pytest.raises(ValueError):
+        series.bulk_update({"seriesIds": [1], "monitored": True})
+
+
+@pytest.mark.asyncio
+async def test_async_series_delete_single():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    series = AsyncSeries(mock_handler)
+
+    assert await series.delete(1, delete_files=True, add_exclusion=True) is True
+
+    mock_handler.request.assert_called_once_with(
+        "series/1",
+        method="DELETE",
+        params={"deleteFiles": True, "addImportListExclusion": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_series_delete_list_sends_flags_in_body():
+    """Regression guard modelled on #190, async client."""
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    series = AsyncSeries(mock_handler)
+
+    assert await series.delete([1, 2], delete_files=True, add_exclusion=True) is True
+
+    mock_handler.request.assert_called_once_with(
+        "series/editor",
+        method="DELETE",
+        json_data={"deleteFiles": True, "addImportListExclusion": True, "seriesIds": [1, 2]},
+    )
+    assert "params" not in mock_handler.request.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_async_series_bulk_update():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    mock_handler.request.return_value = [{"id": 1, "monitored": False}]
+    series = AsyncSeries(mock_handler)
+
+    result = await series.bulk_update({"seriesIds": [1], "monitored": False})
+
+    mock_handler.request.assert_called_once_with(
+        "series/editor",
+        method="PUT",
+        json_data={"seriesIds": [1], "monitored": False},
+    )
+    assert result == [{"id": 1, "monitored": False}]


### PR DESCRIPTION
## Description

`SonarrAPI` never exposed `/series/editor`, so there was no way to bulk edit or bulk delete series even though Radarr already exposes the equivalent movie endpoint. `series.delete()` also had no way to add a series to the import list exclusions while deleting it.

This adds:

- **`series.bulk_update(data)`** - `PUT series/editor`. Takes a dict containing a `seriesIds` list plus the fields to apply, e.g. `{"seriesIds": [1, 2], "monitored": True}`, and returns the list of updated series records. Naming follows the existing `bulk_delete` convention (`common/queue.py`, `common/blocklist.py`).
- **`series.delete(item_id, delete_files=False, add_exclusion=False)`** - `item_id` now accepts a single ID or a list of IDs, mirroring `radarr/movie.py`. A single ID keeps using `DELETE series/{id}` with query parameters; a list uses `DELETE series/editor` with a JSON body of `seriesIds` plus the flags. The new `add_exclusion` flag maps to Sonarr's `addImportListExclusion` and works on both paths.

### The #190 trap, confirmed for Sonarr

`series/editor` binds its flags from the **request body only**, exactly like `movie/editor` in #190. Verified against a live Sonarr 4.0.19.2979:

| Request | Result |
| --- | --- |
| `DELETE series/editor`, body `{"seriesIds": [id]}`, `deleteFiles`/`addImportListExclusion` in the **query string** | `200` - series removed from the DB, but **files left on disk** and **no exclusion added** |
| `DELETE series/editor`, body `{"seriesIds": [id], "deleteFiles": true, "addImportListExclusion": true}` | `200` - series removed, folder and files deleted, exclusion added |

So the list path deliberately sends the flags as `json_data` and no `params`, and the unit tests assert `"params" not in call_args.kwargs` to pin that.

Endpoint method support, also confirmed live: `PUT /api/v3/series/editor` -> `202` (returns a JSON array of the updated series), `DELETE /api/v3/series/editor` -> `200`, `POST /api/v3/series/editor` -> `405`.

### Return type of `series.delete()`

`series.delete()` already returned `bool` (unlike `movie.delete()`, which returns `None`). That is kept as-is - it still returns `True` - so this is a purely additive, non-breaking change for existing callers and for the existing integration test that asserts `... is True`.

## Related issues

Fixes #171
Refs #175 (the Sonarr half - `add_exclusion` on `series.delete`; Radarr's `movie.delete` already had it)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

Unit tests in `tests/sonarr/test_series.py` (sync and async) covering the single-ID query-string path, the list body path including the `params` regression guard, defaults, and `bulk_update` including its non-list response guard.

Integration test `test_sonarr_series_bulk_update_and_bulk_delete` in `tests/integration/test_sonarr_series.py` adds two series, bulk updates them in one request, and bulk deletes them in one request.

End-to-end against a live Sonarr `4.0.19.2979` container, with both the sync and async clients, adding real series and creating real season folders and `.mkv` files inside the container first:

- `bulk_update({"seriesIds": [a, b], "monitored": True})` returned both updated records and the change persisted on re-read.
- `delete([a, b], delete_files=True, add_exclusion=True)` removed both series, **both series folders and their files were gone from disk**, and both titles appeared in `/importlistexclusion`.
- `delete([a])` with defaults removed the series but left the folder and files in place and added no exclusion.
- `delete(a, delete_files=True, add_exclusion=True)` (single ID) removed the series, deleted its folder and files, and added the exclusion.

- [x] I have added new tests where required
- [x] I have run `pre-commit run --all-files` (sync generation, ruff, ruff-format, mypy) and the non-integration test suite locally and passed
- [x] I have tested this feature in a python script

## Summary by Sourcery

Add bulk series editing and flexible deletion support to the Sonarr clients.

New Features:
- Add synchronous and asynchronous bulk series updates through Sonarr’s series editor endpoint.
- Support deleting one or multiple series, including optional file removal and import-list exclusions.

Enhancements:
- Validate that bulk update requests return a list of updated series records.
- Document the Sonarr bulk series update endpoint as available.

Tests:
- Add sync, async, and integration coverage for bulk updates and single- or multi-series deletion behavior.