### PR TITLE
fix(bazarr): mount the test config where Bazarr reads it and fix providers

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -74,7 +74,8 @@ services:
       - PGID=123
       - TZ=Europe/London
     volumes:
-      - ../tests/docker_configs/bazarr/config/config.yaml:/config/config.yaml:rw
+      # Bazarr reads /config/config/config.yaml, not /config/config.yaml
+      - ../tests/docker_configs/bazarr/config/config.yaml:/config/config/config.yaml:rw
     ports:
       - 6767:6767
     restart: unless-stopped

--- a/src/pyarr/_async/bazarr/providers.py
+++ b/src/pyarr/_async/bazarr/providers.py
@@ -1,17 +1,17 @@
 from pyarr._async.common.base import CommonActions
-from pyarr.types import JsonArray
+from pyarr.types import JsonObject
 
 
 class Providers(CommonActions):
     """Subtitle provider actions for Bazarr."""
 
-    async def get(self) -> JsonArray:
-        """Returns the list of subtitle providers.
+    async def get(self) -> JsonObject:
+        """Returns the subtitle providers Bazarr knows about.
 
         Returns:
-            JsonArray: List of dictionaries with items.
+            JsonObject: Dictionary with a ``data`` list of providers.
         """
         response = await self.handler.request("providers")
-        if isinstance(response, list):
+        if isinstance(response, dict):
             return response
-        raise ValueError("Expected a list response from the 'providers' endpoint")
+        raise ValueError("Expected a dictionary response from the 'providers' endpoint")

--- a/src/pyarr/_sync/bazarr/providers.py
+++ b/src/pyarr/_sync/bazarr/providers.py
@@ -4,19 +4,19 @@
 # """
 
 from pyarr._sync.common.base import CommonActions
-from pyarr.types import JsonArray
+from pyarr.types import JsonObject
 
 
 class Providers(CommonActions):
     """Subtitle provider actions for Bazarr."""
 
-    def get(self) -> JsonArray:
-        """Returns the list of subtitle providers.
+    def get(self) -> JsonObject:
+        """Returns the subtitle providers Bazarr knows about.
 
         Returns:
-            JsonArray: List of dictionaries with items.
+            JsonObject: Dictionary with a ``data`` list of providers.
         """
         response = self.handler.request("providers")
-        if isinstance(response, list):
+        if isinstance(response, dict):
             return response
-        raise ValueError("Expected a list response from the 'providers' endpoint")
+        raise ValueError("Expected a dictionary response from the 'providers' endpoint")

--- a/tests/bazarr/test_metadata.py
+++ b/tests/bazarr/test_metadata.py
@@ -7,6 +7,7 @@ import pytest
 
 from pyarr._async.bazarr.episodes import Episodes as AsyncEpisodes
 from pyarr._async.bazarr.movies import Movies as AsyncMovies
+from pyarr._async.bazarr.providers import Providers as AsyncProviders
 from pyarr._async.bazarr.series import Series as AsyncSeries
 from pyarr._async.utils.http import RequestHandler as AsyncRequestHandler
 from pyarr._sync.bazarr.episodes import Episodes
@@ -270,3 +271,24 @@ def test_providers_get_rejects_non_dict_response():
 
     with pytest.raises(ValueError, match="Expected a dictionary response"):
         providers.get()
+
+
+@pytest.mark.asyncio
+async def test_async_providers_get():
+    """Bazarr answers /api/providers with an enveloped object, not a bare list."""
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    mock_handler.request.return_value = {"data": []}
+    providers = AsyncProviders(mock_handler)
+
+    assert await providers.get() == {"data": []}
+    mock_handler.request.assert_called_once_with("providers")
+
+
+@pytest.mark.asyncio
+async def test_async_providers_get_rejects_non_dict_response():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    mock_handler.request.return_value = []
+    providers = AsyncProviders(mock_handler)
+
+    with pytest.raises(ValueError, match="Expected a dictionary response"):
+        await providers.get()

--- a/tests/bazarr/test_metadata.py
+++ b/tests/bazarr/test_metadata.py
@@ -10,6 +10,7 @@ from pyarr._async.bazarr.movies import Movies as AsyncMovies
 from pyarr._async.bazarr.series import Series as AsyncSeries
 from pyarr._async.utils.http import RequestHandler as AsyncRequestHandler
 from pyarr._sync.bazarr.episodes import Episodes
+from pyarr._sync.bazarr.providers import Providers
 from pyarr._sync.bazarr.movies import Movies
 from pyarr._sync.bazarr.series import Series
 from pyarr._sync.utils.http import RequestHandler
@@ -250,3 +251,22 @@ async def test_async_episodes_get_rejects_non_dict_response():
 
     with pytest.raises(ValueError, match="Expected a dictionary response"):
         await episodes.get(series_id=101)
+
+
+def test_providers_get():
+    """Bazarr answers /api/providers with an enveloped object, not a bare list."""
+    mock_handler = MagicMock(spec=RequestHandler)
+    mock_handler.request.return_value = {"data": []}
+    providers = Providers(mock_handler)
+
+    assert providers.get() == {"data": []}
+    mock_handler.request.assert_called_once_with("providers")
+
+
+def test_providers_get_rejects_non_dict_response():
+    mock_handler = MagicMock(spec=RequestHandler)
+    mock_handler.request.return_value = []
+    providers = Providers(mock_handler)
+
+    with pytest.raises(ValueError, match="Expected a dictionary response"):
+        providers.get()

--- a/tests/integration/test_bazarr.py
+++ b/tests/integration/test_bazarr.py
@@ -2,32 +2,30 @@ from pyarr import Bazarr
 
 
 def test_bazarr_system_status(bazarr_client: Bazarr):
-    try:
-        status = bazarr_client.system.get_status()
-        assert isinstance(status, dict)
-    except Exception:
-        pass
-
-
-def test_bazarr_wanted(bazarr_client: Bazarr):
-    try:
-        wanted = bazarr_client.wanted.get(page=1, page_size=10)
-        assert isinstance(wanted, dict)
-    except Exception:
-        pass
-
-
-def test_bazarr_subtitles(bazarr_client: Bazarr):
-    try:
-        subtitles = bazarr_client.subtitles.get()
-        assert isinstance(subtitles, list)
-    except Exception:
-        pass
+    status = bazarr_client.system.get_status()
+    assert isinstance(status, dict)
+    assert isinstance(status["data"], dict)
 
 
 def test_bazarr_providers(bazarr_client: Bazarr):
-    try:
-        providers = bazarr_client.providers.get()
-        assert isinstance(providers, list)
-    except Exception:
-        pass
+    providers = bazarr_client.providers.get()
+    assert isinstance(providers, dict)
+    assert isinstance(providers["data"], list)
+
+
+def test_bazarr_series(bazarr_client: Bazarr):
+    series = bazarr_client.series.get()
+    assert isinstance(series, dict)
+    assert isinstance(series["data"], list)
+
+
+def test_bazarr_movies(bazarr_client: Bazarr):
+    movies = bazarr_client.movies.get()
+    assert isinstance(movies, dict)
+    assert isinstance(movies["data"], list)
+
+
+def test_bazarr_episodes(bazarr_client: Bazarr):
+    episodes = bazarr_client.episodes.get(series_id=[1, 2])
+    assert isinstance(episodes, dict)
+    assert isinstance(episodes["data"], list)


### PR DESCRIPTION
## Description

The follow-up found while working on #189. It turned out to be more than a mount path.

### The mount path

`.ci/docker-compose.yml` mounted the Bazarr config at `/config/config.yaml`, but the linuxserver image reads `/config/config/config.yaml` and generates its own file there on first start. The mounted file was never read, so the API key committed in `tests/integration/conftest.py` returned 401 on every call.

Verified both ways against Bazarr v1.6.0-ls360:

| mount | committed key |
|---|---|
| `/config/config.yaml` (before) | `401` |
| `/config/config/config.yaml` (after) | `200` |

### The tests were decorative

Every test in `tests/integration/test_bazarr.py` was wrapped in `try/except Exception: pass`, so the 401s were swallowed and the file reported green while asserting nothing. The wrappers are gone, so the tests can fail:

- old mount: **5 failed** (401)
- corrected mount: **5 passed**

### Which exposed a real client bug

With auth working, `providers.get()` turned out to be unable to succeed against a live Bazarr at all. `/api/providers` answers `{"data": []}` - an enveloped object, not a bare list - so the `isinstance(response, list)` guard raised `ValueError` every time. It now returns `JsonObject`, consistent with the `series`, `movies` and `episodes` modules added in 6.7.0. Two unit tests cover the envelope and the guard.

Like the `manual_import` fix in #197, this is technically a signature change to a method that had a 100% failure rate, so no working code can depend on the old shape.

### Two tests dropped rather than kept green

- `subtitles.get()` legitimately requires parameters - a bare call is a 400 from Bazarr, correctly. Testing it properly needs a real subtitle file on disk.
- `bazarr.wanted` is wired to `subtitles/wanted`, which does not exist. Bazarr answers it with **200 and the SPA HTML page**, so the client hands back `{"message": "<!doctype html>..."}`. The real endpoints are `/api/episodes/wanted` and `/api/movies/wanted`, which is a public API shape question (one accessor becomes two), so it belongs with the #192 decision rather than being quietly patched here.

## Related issues

Refs #192, follow-up from #189

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI / Tests update

## How has this been tested

- [x] Integration tests verified in both directions: 5 failed on the old mount, 5 passed on the corrected one
- [x] `providers.get()` exercised against the live container through the pyarr client
- [x] 26 unit tests pass in `tests/bazarr`
- [x] `pre-commit run --all-files` passes, including sync parity and mypy

## Note for local runs

The container rewrites the mounted config, so `tests/docker_configs/bazarr/config/config.yaml` shows as modified after a run and needs `git checkout --`. This matches every other service in that compose file. A read-only mount avoids the churn and the API still works, but Bazarr then logs `Read-only file system` errors while trying to persist settings, so `:rw` is the better trade.

## Summary by Sourcery

Fix Bazarr integration coverage and provider response handling so live API behavior is validated correctly.

Bug Fixes:
- Correct Bazarr integration configuration mounting so the container reads the intended authenticated test configuration.
- Update synchronous and asynchronous provider accessors to accept Bazarr’s enveloped object response.
- Make Bazarr integration tests fail on real errors instead of silently swallowing exceptions.

Tests:
- Add synchronous and asynchronous unit coverage for the provider response envelope and invalid response handling.
- Replace invalid or misleading Bazarr integration checks with authenticated coverage for system status, providers, series, movies, and episodes.