### PR TITLE
docs: correct APIs pluralisation and a README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <h3 align="center">Pyarr</h3>
 
   <p align="center">
-    A Python library for interacting with the `arr` API's
+    A Python library for interacting with the `arr` APIs
   </p>
     <br />
     <br />
@@ -62,7 +62,7 @@
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
-A Python library for the following `arr` API's:
+A Python library for the following `arr` APIs:
 
 * Sonarr
 * Radarr
@@ -73,7 +73,7 @@ A Python library for the following `arr` API's:
 * Bazarr
 * Whisparr
 
-The library supports both **Synchronous** and **Asynchronous** (asyncio) usage, providing a consistent API for both. It returns results in JSON format for ease of use, this also reduces the risk of failue when the arr APIs are updated.
+The library supports both **Synchronous** and **Asynchronous** (asyncio) usage, providing a consistent API for both. It returns results in JSON format for ease of use, this also reduces the risk of failure when the arr APIs are updated.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pyarr"
 version = "6.7.0"
-description = "Synchronous Sonarr, Radarr, Lidarr, Prowlarr, Bazarr, Dispatcharr and Readarr API's for Python"
+description = "Synchronous Sonarr, Radarr, Lidarr, Prowlarr, Bazarr, Dispatcharr and Readarr APIs for Python"
 authors = [
     { name = "Steven Marks", email = "marksie1988@users.noreply.github.com" }
 ]


### PR DESCRIPTION
## Description

`API's` is possessive, not plural. Corrected to `APIs` in three places:

- `pyproject.toml` description - this one is user visible on PyPI and in `pip show`, which is why it is worth a commit of its own
- `README.md`, two occurrences

Also fixed `failue` to `failure` in the README paragraph two lines below one of them, since it is the same kind of fix in the same file.

Raised by Sourcery on the 6.7.0 release PR (#203). I resolved it there rather than amending the release, so that an unrelated string change did not ride along inside a release commit.

## Type of change

- [x] Documentation update

## How has this been tested

- [x] `pre-commit run --all-files` passes all 8 hooks
- [x] No code paths touched, so no behaviour to test

Note: `docs:` is a hidden type in `.github/release-please-config.json` and does not bump a version, so the PyPI description will update with the next release rather than immediately.

## Summary by Sourcery

Documentation:
- Correct API pluralization and fix a spelling error in the README and package metadata.