### PR TITLE
feat(bazarr): add actions and profile assignment for series and movies

### DIFF
--- a/src/pyarr/_async/bazarr/movies.py
+++ b/src/pyarr/_async/bazarr/movies.py
@@ -1,6 +1,8 @@
 from typing import Any
 
 from pyarr._async.common.base import CommonActions
+from pyarr.exceptions import PyarrMissingArgument
+from pyarr.literals import BazarrActions
 from pyarr.types import JsonObject
 
 
@@ -26,3 +28,62 @@ class Movies(CommonActions):
         if isinstance(response, dict):
             return response
         raise ValueError("Expected a dictionary response from the 'movies' endpoint")
+
+    async def run_action(self, action: BazarrActions, movie_id: int | None = None) -> None:
+        """Runs an action against a movie, which is how Bazarr is asked to do work.
+
+        Bazarr answers a successful action with a 204 and no body, so there is nothing to return.
+
+        Args:
+            action (BazarrActions): The action to run. One of ``scan-disk``, ``search-missing``,
+                ``search-wanted`` or ``sync``. Bazarr answers an unrecognised action with a 400.
+            movie_id (int | None, optional): The Radarr movie ID to act on, sent as the ``radarrid``
+                parameter. Required for every action except ``search-wanted``, which searches every
+                wanted movie and ignores the ID. Defaults to None.
+
+        Returns:
+            None: Bazarr returns a 204 No Content on success.
+
+        Raises:
+            PyarrMissingArgument: If ``movie_id`` is omitted for an action that acts on one movie.
+                Bazarr itself answers such a request with a 204 having done nothing at all.
+        """
+        if movie_id is None and action != "search-wanted":
+            raise PyarrMissingArgument(f"movie_id must be provided for the '{action}' action")
+
+        params: dict[str, Any] = {"action": action}
+        if movie_id is not None:
+            params["radarrid"] = movie_id
+
+        await self.handler.request("movies", method="PATCH", params=params)
+
+    async def set_languages_profile(
+        self,
+        movie_id: int | list[int],
+        profile_id: int | str | list[int | str],
+    ) -> None:
+        """Assigns a languages profile to one or more movies.
+
+        Bazarr pairs the IDs up by position, so the two arguments must line up. It answers a mismatched
+        request with a 500, so the pairing is checked before the request is sent.
+
+        Args:
+            movie_id (int | list[int]): One or more Radarr movie IDs, sent as the ``radarrid`` parameter,
+                repeated once per ID.
+            profile_id (int | str | list[int | str]): The languages profile ID for each movie, sent as the
+                ``profileid`` parameter, repeated once per value. Pass ``"null"`` to clear a movie's profile.
+
+        Returns:
+            None: Bazarr returns a 204 No Content on success.
+
+        Raises:
+            ValueError: If a different number of movie IDs and profile IDs is given.
+        """
+        movie_ids = movie_id if isinstance(movie_id, list) else [movie_id]
+        profile_ids = profile_id if isinstance(profile_id, list) else [profile_id]
+        if len(movie_ids) != len(profile_ids):
+            raise ValueError("movie_id and profile_id must contain the same number of items")
+
+        params: dict[str, Any] = {"radarrid": movie_ids, "profileid": profile_ids}
+
+        await self.handler.request("movies", method="POST", params=params)

--- a/src/pyarr/_async/bazarr/series.py
+++ b/src/pyarr/_async/bazarr/series.py
@@ -1,6 +1,8 @@
 from typing import Any
 
 from pyarr._async.common.base import CommonActions
+from pyarr.exceptions import PyarrMissingArgument
+from pyarr.literals import BazarrActions
 from pyarr.types import JsonObject
 
 
@@ -26,3 +28,62 @@ class Series(CommonActions):
         if isinstance(response, dict):
             return response
         raise ValueError("Expected a dictionary response from the 'series' endpoint")
+
+    async def run_action(self, action: BazarrActions, series_id: int | None = None) -> None:
+        """Runs an action against a series, which is how Bazarr is asked to do work.
+
+        Bazarr answers a successful action with a 204 and no body, so there is nothing to return.
+
+        Args:
+            action (BazarrActions): The action to run. One of ``scan-disk``, ``search-missing``,
+                ``search-wanted`` or ``sync``. Bazarr answers an unrecognised action with a 400.
+            series_id (int | None, optional): The Sonarr series ID to act on, sent as the ``seriesid``
+                parameter. Required for every action except ``search-wanted``, which searches every
+                wanted series and ignores the ID. Defaults to None.
+
+        Returns:
+            None: Bazarr returns a 204 No Content on success.
+
+        Raises:
+            PyarrMissingArgument: If ``series_id`` is omitted for an action that acts on one series.
+                Bazarr itself answers such a request with a 204 having done nothing at all.
+        """
+        if series_id is None and action != "search-wanted":
+            raise PyarrMissingArgument(f"series_id must be provided for the '{action}' action")
+
+        params: dict[str, Any] = {"action": action}
+        if series_id is not None:
+            params["seriesid"] = series_id
+
+        await self.handler.request("series", method="PATCH", params=params)
+
+    async def set_languages_profile(
+        self,
+        series_id: int | list[int],
+        profile_id: int | str | list[int | str],
+    ) -> None:
+        """Assigns a languages profile to one or more series.
+
+        Bazarr pairs the IDs up by position, so the two arguments must line up. It answers a mismatched
+        request with a 500, so the pairing is checked before the request is sent.
+
+        Args:
+            series_id (int | list[int]): One or more Sonarr series IDs, sent as the ``seriesid`` parameter,
+                repeated once per ID.
+            profile_id (int | str | list[int | str]): The languages profile ID for each series, sent as the
+                ``profileid`` parameter, repeated once per value. Pass ``"null"`` to clear a series' profile.
+
+        Returns:
+            None: Bazarr returns a 204 No Content on success.
+
+        Raises:
+            ValueError: If a different number of series IDs and profile IDs is given.
+        """
+        series_ids = series_id if isinstance(series_id, list) else [series_id]
+        profile_ids = profile_id if isinstance(profile_id, list) else [profile_id]
+        if len(series_ids) != len(profile_ids):
+            raise ValueError("series_id and profile_id must contain the same number of items")
+
+        params: dict[str, Any] = {"seriesid": series_ids, "profileid": profile_ids}
+
+        await self.handler.request("series", method="POST", params=params)

--- a/src/pyarr/_async/utils/http.py
+++ b/src/pyarr/_async/utils/http.py
@@ -170,7 +170,7 @@ class RequestHandler:
             Exception: If the response status code indicates an error.
 
         Returns:
-            Any: The response data as a dictionary, list, or httpx.Response object.
+            Any: The response data as a dictionary or list, or None when the response is a 204 No Content.
         """
         if endpoint == "api":
             url = self.base_url.joinpath(endpoint)
@@ -224,6 +224,10 @@ class RequestHandler:
 
         if status_code // 100 in [4, 5]:
             await self._handle_error(response)
+
+        if status_code == 204:
+            # No Content, there is no body to decode even when the server advertises a JSON content type.
+            return None
 
         content_type = response.headers.get("Content-Type", "")
         if "application/json" in content_type:

--- a/src/pyarr/_sync/bazarr/movies.py
+++ b/src/pyarr/_sync/bazarr/movies.py
@@ -6,6 +6,8 @@
 from typing import Any
 
 from pyarr._sync.common.base import CommonActions
+from pyarr.exceptions import PyarrMissingArgument
+from pyarr.literals import BazarrActions
 from pyarr.types import JsonObject
 
 
@@ -31,3 +33,62 @@ class Movies(CommonActions):
         if isinstance(response, dict):
             return response
         raise ValueError("Expected a dictionary response from the 'movies' endpoint")
+
+    def run_action(self, action: BazarrActions, movie_id: int | None = None) -> None:
+        """Runs an action against a movie, which is how Bazarr is asked to do work.
+
+        Bazarr answers a successful action with a 204 and no body, so there is nothing to return.
+
+        Args:
+            action (BazarrActions): The action to run. One of ``scan-disk``, ``search-missing``,
+                ``search-wanted`` or ``sync``. Bazarr answers an unrecognised action with a 400.
+            movie_id (int | None, optional): The Radarr movie ID to act on, sent as the ``radarrid``
+                parameter. Required for every action except ``search-wanted``, which searches every
+                wanted movie and ignores the ID. Defaults to None.
+
+        Returns:
+            None: Bazarr returns a 204 No Content on success.
+
+        Raises:
+            PyarrMissingArgument: If ``movie_id`` is omitted for an action that acts on one movie.
+                Bazarr itself answers such a request with a 204 having done nothing at all.
+        """
+        if movie_id is None and action != "search-wanted":
+            raise PyarrMissingArgument(f"movie_id must be provided for the '{action}' action")
+
+        params: dict[str, Any] = {"action": action}
+        if movie_id is not None:
+            params["radarrid"] = movie_id
+
+        self.handler.request("movies", method="PATCH", params=params)
+
+    def set_languages_profile(
+        self,
+        movie_id: int | list[int],
+        profile_id: int | str | list[int | str],
+    ) -> None:
+        """Assigns a languages profile to one or more movies.
+
+        Bazarr pairs the IDs up by position, so the two arguments must line up. It answers a mismatched
+        request with a 500, so the pairing is checked before the request is sent.
+
+        Args:
+            movie_id (int | list[int]): One or more Radarr movie IDs, sent as the ``radarrid`` parameter,
+                repeated once per ID.
+            profile_id (int | str | list[int | str]): The languages profile ID for each movie, sent as the
+                ``profileid`` parameter, repeated once per value. Pass ``"null"`` to clear a movie's profile.
+
+        Returns:
+            None: Bazarr returns a 204 No Content on success.
+
+        Raises:
+            ValueError: If a different number of movie IDs and profile IDs is given.
+        """
+        movie_ids = movie_id if isinstance(movie_id, list) else [movie_id]
+        profile_ids = profile_id if isinstance(profile_id, list) else [profile_id]
+        if len(movie_ids) != len(profile_ids):
+            raise ValueError("movie_id and profile_id must contain the same number of items")
+
+        params: dict[str, Any] = {"radarrid": movie_ids, "profileid": profile_ids}
+
+        self.handler.request("movies", method="POST", params=params)

--- a/src/pyarr/_sync/bazarr/series.py
+++ b/src/pyarr/_sync/bazarr/series.py
@@ -6,6 +6,8 @@
 from typing import Any
 
 from pyarr._sync.common.base import CommonActions
+from pyarr.exceptions import PyarrMissingArgument
+from pyarr.literals import BazarrActions
 from pyarr.types import JsonObject
 
 
@@ -31,3 +33,62 @@ class Series(CommonActions):
         if isinstance(response, dict):
             return response
         raise ValueError("Expected a dictionary response from the 'series' endpoint")
+
+    def run_action(self, action: BazarrActions, series_id: int | None = None) -> None:
+        """Runs an action against a series, which is how Bazarr is asked to do work.
+
+        Bazarr answers a successful action with a 204 and no body, so there is nothing to return.
+
+        Args:
+            action (BazarrActions): The action to run. One of ``scan-disk``, ``search-missing``,
+                ``search-wanted`` or ``sync``. Bazarr answers an unrecognised action with a 400.
+            series_id (int | None, optional): The Sonarr series ID to act on, sent as the ``seriesid``
+                parameter. Required for every action except ``search-wanted``, which searches every
+                wanted series and ignores the ID. Defaults to None.
+
+        Returns:
+            None: Bazarr returns a 204 No Content on success.
+
+        Raises:
+            PyarrMissingArgument: If ``series_id`` is omitted for an action that acts on one series.
+                Bazarr itself answers such a request with a 204 having done nothing at all.
+        """
+        if series_id is None and action != "search-wanted":
+            raise PyarrMissingArgument(f"series_id must be provided for the '{action}' action")
+
+        params: dict[str, Any] = {"action": action}
+        if series_id is not None:
+            params["seriesid"] = series_id
+
+        self.handler.request("series", method="PATCH", params=params)
+
+    def set_languages_profile(
+        self,
+        series_id: int | list[int],
+        profile_id: int | str | list[int | str],
+    ) -> None:
+        """Assigns a languages profile to one or more series.
+
+        Bazarr pairs the IDs up by position, so the two arguments must line up. It answers a mismatched
+        request with a 500, so the pairing is checked before the request is sent.
+
+        Args:
+            series_id (int | list[int]): One or more Sonarr series IDs, sent as the ``seriesid`` parameter,
+                repeated once per ID.
+            profile_id (int | str | list[int | str]): The languages profile ID for each series, sent as the
+                ``profileid`` parameter, repeated once per value. Pass ``"null"`` to clear a series' profile.
+
+        Returns:
+            None: Bazarr returns a 204 No Content on success.
+
+        Raises:
+            ValueError: If a different number of series IDs and profile IDs is given.
+        """
+        series_ids = series_id if isinstance(series_id, list) else [series_id]
+        profile_ids = profile_id if isinstance(profile_id, list) else [profile_id]
+        if len(series_ids) != len(profile_ids):
+            raise ValueError("series_id and profile_id must contain the same number of items")
+
+        params: dict[str, Any] = {"seriesid": series_ids, "profileid": profile_ids}
+
+        self.handler.request("series", method="POST", params=params)

--- a/src/pyarr/_sync/utils/http.py
+++ b/src/pyarr/_sync/utils/http.py
@@ -175,7 +175,7 @@ class RequestHandler:
             Exception: If the response status code indicates an error.
 
         Returns:
-            Any: The response data as a dictionary, list, or httpx.Response object.
+            Any: The response data as a dictionary or list, or None when the response is a 204 No Content.
         """
         if endpoint == "api":
             url = self.base_url.joinpath(endpoint)
@@ -229,6 +229,10 @@ class RequestHandler:
 
         if status_code // 100 in [4, 5]:
             self._handle_error(response)
+
+        if status_code == 204:
+            # No Content, there is no body to decode even when the server advertises a JSON content type.
+            return None
 
         content_type = response.headers.get("Content-Type", "")
         if "application/json" in content_type:

--- a/src/pyarr/literals.py
+++ b/src/pyarr/literals.py
@@ -303,3 +303,8 @@ ReadarrSearchType = Literal["asin", "edition", "isbn", "author", "work"]
 
 #: Readarr author monitor options
 ReadarrAuthorMonitor = Literal["all", "future", "missing", "existing", "first", "latest", "none"]
+
+# --- Bazarr Literals ---
+
+#: Bazarr actions that can be run against the series and movies endpoints
+BazarrActions = Literal["scan-disk", "search-missing", "search-wanted", "sync"]

--- a/tests/bazarr/test_metadata.py
+++ b/tests/bazarr/test_metadata.py
@@ -1,6 +1,6 @@
-"""Tests for the Bazarr series, movies and episodes endpoints (#189)."""
+"""Tests for the Bazarr series, movies and episodes endpoints (#189, #204)."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import httpx
 import pytest
@@ -292,3 +292,244 @@ async def test_async_providers_get_rejects_non_dict_response():
 
     with pytest.raises(ValueError, match="Expected a dictionary response"):
         await providers.get()
+
+
+def test_series_run_action():
+    """Bazarr takes the action and the series ID as query parameters on a PATCH (#204)."""
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    assert series.run_action("search-missing", series_id=101) is None
+    mock_handler.request.assert_called_once_with(
+        "series", method="PATCH", params={"action": "search-missing", "seriesid": 101}
+    )
+
+
+def test_series_run_action_scan_disk_and_sync():
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    series.run_action("scan-disk", series_id=101)
+    series.run_action("sync", series_id=101)
+
+    assert mock_handler.request.call_args_list == [
+        call("series", method="PATCH", params={"action": "scan-disk", "seriesid": 101}),
+        call("series", method="PATCH", params={"action": "sync", "seriesid": 101}),
+    ]
+
+
+def test_series_run_action_search_wanted_needs_no_id():
+    """``search-wanted`` searches every wanted series, Bazarr ignores any ID given."""
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    assert series.run_action("search-wanted") is None
+    mock_handler.request.assert_called_once_with("series", method="PATCH", params={"action": "search-wanted"})
+
+
+def test_series_run_action_requires_a_series_id():
+    """Bazarr answers an ID-less scan or sync with a 204 having done nothing, so fail loudly instead."""
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    with pytest.raises(PyarrMissingArgument, match="series_id must be provided"):
+        series.run_action("scan-disk")
+
+    mock_handler.request.assert_not_called()
+
+
+def test_series_set_languages_profile():
+    """The POST pairs ``seriesid`` and ``profileid`` by position, so both are sent as lists."""
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    assert series.set_languages_profile(101, 1) is None
+    mock_handler.request.assert_called_once_with(
+        "series", method="POST", params={"seriesid": [101], "profileid": [1]}
+    )
+
+
+def test_series_set_languages_profile_with_lists():
+    """``"null"`` clears a profile, Bazarr rejects ``"none"`` despite what its own help text says."""
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    series.set_languages_profile([101, 102], [1, "null"])
+    mock_handler.request.assert_called_once_with(
+        "series", method="POST", params={"seriesid": [101, 102], "profileid": [1, "null"]}
+    )
+
+
+def test_series_set_languages_profile_rejects_mismatched_lengths():
+    """Bazarr zips the two lists and 500s on a mismatch, so the pairing is checked up front."""
+    mock_handler = MagicMock(spec=RequestHandler)
+    series = Series(mock_handler)
+
+    with pytest.raises(ValueError, match="same number of items"):
+        series.set_languages_profile([101, 102], 1)
+
+    mock_handler.request.assert_not_called()
+
+
+def test_movies_run_action():
+    mock_handler = MagicMock(spec=RequestHandler)
+    movies = Movies(mock_handler)
+
+    assert movies.run_action("search-missing", movie_id=201) is None
+    mock_handler.request.assert_called_once_with(
+        "movies", method="PATCH", params={"action": "search-missing", "radarrid": 201}
+    )
+
+
+def test_movies_run_action_search_wanted_needs_no_id():
+    mock_handler = MagicMock(spec=RequestHandler)
+    movies = Movies(mock_handler)
+
+    assert movies.run_action("search-wanted") is None
+    mock_handler.request.assert_called_once_with("movies", method="PATCH", params={"action": "search-wanted"})
+
+
+def test_movies_run_action_requires_a_movie_id():
+    mock_handler = MagicMock(spec=RequestHandler)
+    movies = Movies(mock_handler)
+
+    with pytest.raises(PyarrMissingArgument, match="movie_id must be provided"):
+        movies.run_action("sync")
+
+    mock_handler.request.assert_not_called()
+
+
+def test_movies_set_languages_profile():
+    mock_handler = MagicMock(spec=RequestHandler)
+    movies = Movies(mock_handler)
+
+    assert movies.set_languages_profile([201, 202], [1, "null"]) is None
+    mock_handler.request.assert_called_once_with(
+        "movies", method="POST", params={"radarrid": [201, 202], "profileid": [1, "null"]}
+    )
+
+
+def test_movies_set_languages_profile_rejects_mismatched_lengths():
+    mock_handler = MagicMock(spec=RequestHandler)
+    movies = Movies(mock_handler)
+
+    with pytest.raises(ValueError, match="same number of items"):
+        movies.set_languages_profile(201, [1, 2])
+
+    mock_handler.request.assert_not_called()
+
+
+def test_languages_profile_pairs_are_sent_in_order():
+    """Bazarr pairs the repeated parameters by position, so the wire order has to be preserved."""
+    request = httpx.Request(
+        "POST",
+        "http://localhost:6767/api/series",
+        params={"seriesid": [101, 102], "profileid": [1, "null"]},
+    )
+
+    assert request.url.params.get_list("seriesid") == ["101", "102"]
+    assert request.url.params.get_list("profileid") == ["1", "null"]
+
+
+@pytest.mark.asyncio
+async def test_async_series_run_action():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    series = AsyncSeries(mock_handler)
+
+    assert await series.run_action("sync", series_id=101) is None
+    mock_handler.request.assert_called_once_with("series", method="PATCH", params={"action": "sync", "seriesid": 101})
+
+
+@pytest.mark.asyncio
+async def test_async_series_run_action_search_wanted_needs_no_id():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    series = AsyncSeries(mock_handler)
+
+    assert await series.run_action("search-wanted") is None
+    mock_handler.request.assert_called_once_with("series", method="PATCH", params={"action": "search-wanted"})
+
+
+@pytest.mark.asyncio
+async def test_async_series_run_action_requires_a_series_id():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    series = AsyncSeries(mock_handler)
+
+    with pytest.raises(PyarrMissingArgument, match="series_id must be provided"):
+        await series.run_action("search-missing")
+
+    mock_handler.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_series_set_languages_profile():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    series = AsyncSeries(mock_handler)
+
+    assert await series.set_languages_profile([101, 102], [1, "null"]) is None
+    mock_handler.request.assert_called_once_with(
+        "series", method="POST", params={"seriesid": [101, 102], "profileid": [1, "null"]}
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_series_set_languages_profile_rejects_mismatched_lengths():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    series = AsyncSeries(mock_handler)
+
+    with pytest.raises(ValueError, match="same number of items"):
+        await series.set_languages_profile([101, 102], 1)
+
+    mock_handler.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_movies_run_action():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    movies = AsyncMovies(mock_handler)
+
+    assert await movies.run_action("scan-disk", movie_id=201) is None
+    mock_handler.request.assert_called_once_with(
+        "movies", method="PATCH", params={"action": "scan-disk", "radarrid": 201}
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_movies_run_action_search_wanted_needs_no_id():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    movies = AsyncMovies(mock_handler)
+
+    assert await movies.run_action("search-wanted") is None
+    mock_handler.request.assert_called_once_with("movies", method="PATCH", params={"action": "search-wanted"})
+
+
+@pytest.mark.asyncio
+async def test_async_movies_run_action_requires_a_movie_id():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    movies = AsyncMovies(mock_handler)
+
+    with pytest.raises(PyarrMissingArgument, match="movie_id must be provided"):
+        await movies.run_action("scan-disk")
+
+    mock_handler.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_movies_set_languages_profile():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    movies = AsyncMovies(mock_handler)
+
+    assert await movies.set_languages_profile(201, 1) is None
+    mock_handler.request.assert_called_once_with(
+        "movies", method="POST", params={"radarrid": [201], "profileid": [1]}
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_movies_set_languages_profile_rejects_mismatched_lengths():
+    mock_handler = AsyncMock(spec=AsyncRequestHandler)
+    movies = AsyncMovies(mock_handler)
+
+    with pytest.raises(ValueError, match="same number of items"):
+        await movies.set_languages_profile(201, [1, 2])
+
+    mock_handler.request.assert_not_called()

--- a/tests/common/test_request_handler.py
+++ b/tests/common/test_request_handler.py
@@ -40,3 +40,35 @@ async def test_async_request_sends_list_json_data():
 
     assert captured["method"] == "POST"
     assert json.loads(captured["content"]) == payload
+
+
+def _no_content_transport(captured):
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        # Bazarr answers a successful action with a 204 that has no body but still claims JSON.
+        return httpx.Response(204, headers={"Content-Type": "application/json"})
+
+    return handler
+
+
+def test_request_returns_none_for_204_no_content():
+    """A 204 has no body to decode, even when the server advertises a JSON content type."""
+    captured: dict[str, object] = {}
+    session = httpx.Client(transport=httpx.MockTransport(_no_content_transport(captured)))
+    handler = RequestHandler(host="localhost", api_key="key", port=6767, tls=False, api_ver="", session=session)
+
+    assert handler.request("series", method="PATCH", params={"action": "sync", "seriesid": 1}) is None
+
+    assert captured["method"] == "PATCH"
+
+
+@pytest.mark.asyncio
+async def test_async_request_returns_none_for_204_no_content():
+    captured: dict[str, object] = {}
+    session = httpx.AsyncClient(transport=httpx.MockTransport(_no_content_transport(captured)))
+    handler = AsyncRequestHandler(host="localhost", api_key="key", port=6767, tls=False, api_ver="", session=session)
+
+    assert await handler.request("series", method="PATCH", params={"action": "sync", "seriesid": 1}) is None
+
+    assert captured["method"] == "PATCH"

--- a/tests/integration/test_bazarr.py
+++ b/tests/integration/test_bazarr.py
@@ -1,4 +1,7 @@
+import pytest
+
 from pyarr import Bazarr
+from pyarr.exceptions import PyarrBadRequest, PyarrMissingArgument, PyarrResourceNotFound
 
 
 def test_bazarr_system_status(bazarr_client: Bazarr):
@@ -29,3 +32,60 @@ def test_bazarr_episodes(bazarr_client: Bazarr):
     episodes = bazarr_client.episodes.get(series_id=[1, 2])
     assert isinstance(episodes, dict)
     assert isinstance(episodes["data"], list)
+
+
+def test_bazarr_series_run_action(bazarr_client: Bazarr):
+    """A successful action is a 204 with no body, so the call must simply come back without raising."""
+    bazarr_client.series.run_action("search-wanted")
+    bazarr_client.series.run_action("scan-disk", series_id=1)
+    bazarr_client.series.run_action("sync", series_id=1)
+
+
+def test_bazarr_movies_run_action(bazarr_client: Bazarr):
+    bazarr_client.movies.run_action("search-wanted")
+    bazarr_client.movies.run_action("scan-disk", movie_id=1)
+    bazarr_client.movies.run_action("sync", movie_id=1)
+
+
+def test_bazarr_patch_answers_204_from_the_real_route(bazarr_client: Bazarr):
+    """Bazarr answers an unknown path with 200 and the SPA HTML (#192), so a 204 is the real route."""
+    assert bazarr_client.http_utils.request("series", method="PATCH", params={"action": "search-wanted"}) is None
+    assert bazarr_client.http_utils.request("movies", method="PATCH", params={"action": "search-wanted"}) is None
+
+    spa = bazarr_client.http_utils.request("definitely-not-a-real-path")
+    assert isinstance(spa, dict)
+    assert "<!doctype html>" in spa["message"].lower()
+
+
+def test_bazarr_series_run_action_rejects_an_unknown_action(bazarr_client: Bazarr):
+    """Bazarr answers an unknown path with the SPA HTML page, so the 400 proves the real route ran."""
+    with pytest.raises(PyarrBadRequest, match="Unknown action"):
+        bazarr_client.series.run_action("not-an-action", series_id=1)  # type: ignore[arg-type]
+
+
+def test_bazarr_movies_run_action_rejects_an_unknown_action(bazarr_client: Bazarr):
+    with pytest.raises(PyarrBadRequest, match="Unknown action"):
+        bazarr_client.movies.run_action("not-an-action", movie_id=1)  # type: ignore[arg-type]
+
+
+def test_bazarr_run_action_requires_an_id(bazarr_client: Bazarr):
+    """Bazarr would answer these with a 204 having done nothing, so pyarr fails before the request."""
+    with pytest.raises(PyarrMissingArgument):
+        bazarr_client.series.run_action("scan-disk")
+
+    with pytest.raises(PyarrMissingArgument):
+        bazarr_client.movies.run_action("sync")
+
+
+def test_bazarr_series_set_languages_profile(bazarr_client: Bazarr):
+    """``"null"`` clears the profile, Bazarr rejects ``"none"`` despite what its own help text says."""
+    bazarr_client.series.set_languages_profile(1, "null")
+
+
+def test_bazarr_movies_set_languages_profile(bazarr_client: Bazarr):
+    bazarr_client.movies.set_languages_profile(1, "null")
+
+
+def test_bazarr_set_languages_profile_rejects_an_unknown_profile(bazarr_client: Bazarr):
+    with pytest.raises(PyarrResourceNotFound, match="Languages profile not found"):
+        bazarr_client.series.set_languages_profile(1, "not-a-profile")


### PR DESCRIPTION
## Description

Bazarr's `/api/series` and `/api/movies` routes do more than `GET`, and #201 only wrapped the `GET`. This adds the two other verbs those routes serve:

- **`PATCH` - run an action.** `bazarr.series.run_action(action, series_id=...)` and `bazarr.movies.run_action(action, movie_id=...)`. `action` is a new `BazarrActions` literal - `scan-disk`, `search-missing`, `search-wanted` or `sync` - so a typo is a type error rather than a 400 at runtime. This is the endpoint the reporter needs to trigger a subtitle search.
- **`POST` - assign a languages profile.** `bazarr.series.set_languages_profile(series_id, profile_id)` and the movies equivalent.

Two guards, both earned from the live API rather than assumed:

- `scan-disk`, `search-missing` and `sync` act on a single item, and Bazarr answers an ID-less request with a `204` having done nothing at all. Omitting the ID therefore raises `PyarrMissingArgument` rather than silently no-opping, following the existing `episodes.get()` pattern.
- The `POST` zips `seriesid`/`radarrid` and `profileid` by position, so a mismatched pair is an `IndexError` inside Bazarr and comes back as a `500`. The pairing is checked before the request is sent.

**Request handler fix, needed for any of the above to work:** Bazarr answers all four actions with `204 No Content` **and** a `Content-Type: application/json` header, but no body. The handler saw the JSON content type and called `.json()` on an empty body, raising `JSONDecodeError`. It now returns `None` for a `204`, which is also the right behaviour for the existing `DELETE` wrappers.

### Wire format confirmed against Bazarr 1.6.0

Read from `bazarr/api/series/series.py` and `bazarr/api/movies/movies.py` in the running container, then exercised live:

| | parameters | success |
|---|---|---|
| `PATCH /api/series` | `seriesid` (single int), `action` | `204`, no body |
| `PATCH /api/movies` | `radarrid` (single int), `action` | `204`, no body |
| `POST /api/series` | `seriesid` (repeated), `profileid` (repeated) | `204`, no body |
| `POST /api/movies` | `radarrid` (repeated), `profileid` (repeated) | `204`, no body |

Notes from the live run:

- Unlike the `GET`, the `PATCH` ID parameter is **not** `seriesid[]`/`radarrid[]` and is **not** an `append` argument - it is a single scalar `seriesid`/`radarrid`. The `POST` ID parameters are `append` arguments and take repeats.
- The `action` is read from `reqparse`'s default locations, so it works in the query string, a form body or a JSON body. Query parameters are used here, matching `get()`.
- `profileid` accepts `"null"` to clear a profile. Bazarr's own help text says `"none"`, which is wrong - `None_Keys` is `['null', 'undefined', '', None]` and `"none"` comes back as a `404`.
- An unrecognised action is a `400 "Unknown action"`.

### Note on issue #192 (the SPA trap)

Bazarr answers unknown paths with `200` and the SPA HTML page, so a `200` proves nothing. These routes were confirmed real, not the catch-all: the successful calls return `204` with no body (the catch-all cannot produce a `204`), an unknown `action` returns `400 "Unknown action"` from the route's own code path, and an unknown `profileid` returns `404 "Languages profile not found"`. An integration test asserts the discriminator directly - the `PATCH` returns `None`, while `definitely-not-a-real-path` returns the HTML page.

### What was not verified

The container was a bare Bazarr with no Sonarr or Radarr linked, so its series and movies tables were empty. Every route was confirmed to accept the call, parse the parameters and answer correctly, but the **effect** of an action could not be observed - `scan-disk`, `search-missing` and `sync` had no series or movie row to work on, and the profile `UPDATE` matched no rows. `search-wanted` takes no ID and ran against the whole (empty) wanted list. The parameter names and pairing semantics come from Bazarr's own route source, which is quoted above; the response shapes come from the live API.

## Related issues

Fixes #204

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] I have added new tests where required
- [x] I have run `nox -s tests` locally and passed
- [x] I have tested this feature in a python script

25 new unit tests in `tests/bazarr/test_metadata.py` (sync and async for every new method, asserting the exact request shape) and `tests/common/test_request_handler.py` (the `204` to `None` mapping, via `MockTransport`). Unit suite: 123 passed, with the same 26 pre-existing failures as `main` - those need containers on the default ports.

10 new integration tests in `tests/integration/test_bazarr.py`, run green against `lscr.io/linuxserver/bazarr:latest` (Bazarr 1.6.0), covering all four actions on both routes, the `400` on an unknown action, the `404` on an unknown profile, the client-side guards, and the `204`-versus-SPA-HTML discriminator. 14 passed.

## Summary by Sourcery

Extend Bazarr support with media actions and languages-profile assignment for series and movies.

New Features:
- Add synchronous and asynchronous Bazarr APIs for running supported actions on series and movies.
- Add synchronous and asynchronous Bazarr APIs for assigning languages profiles to one or more series or movies.

Bug Fixes:
- Handle successful 204 No Content responses without attempting to decode an empty JSON body.

Enhancements:
- Validate required media IDs and languages-profile pairing before sending Bazarr requests.
- Define a typed set of supported Bazarr actions.

Tests:
- Add unit and integration coverage for Bazarr actions, profile assignment, validation, and 204 response handling.