### PR TITLE
fix(client): expose common components only on clients that support them

### DIFF
--- a/docs/modules/bazarr.rst
+++ b/docs/modules/bazarr.rst
@@ -31,3 +31,14 @@ Subtitles
 ---------
 .. automodule:: pyarr._sync.bazarr.subtitles
     :members:
+
+Wanted
+------
+
+Bazarr has no combined wanted endpoint, so it exposes ``wanted_episodes`` and
+``wanted_movies`` rather than a single ``wanted``. Each uses the shared
+:class:`pyarr._sync.common.wanted.Wanted` component pointed at the matching path.
+
+.. automodule:: pyarr._sync.common.wanted
+    :members:
+    :noindex:

--- a/docs/modules/common.rst
+++ b/docs/modules/common.rst
@@ -29,7 +29,7 @@ The support below was established by probing live instances.
       - Not exposed on that client
 
 Bazarr and Dispatcharr have their own APIs and expose only ``system`` from this set,
-alongside their own client specific components.
+alongside their own client-specific components.
 
 Backup
 ------

--- a/docs/modules/common.rst
+++ b/docs/modules/common.rst
@@ -1,7 +1,35 @@
 Common Components
 =================
 
-These components are available on all Arr clients (Sonarr, Radarr, Lidarr, etc.).
+These components are shared between clients, but they are **not** available on every
+client - each Arr only exposes the ones its API actually answers. Accessing one that a
+client does not support raises ``AttributeError``, so a mistake surfaces immediately
+rather than as a 404 or, on Bazarr and Dispatcharr, a 200 carrying their web page.
+
+The support below was established by probing live instances.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 60
+
+    * - Component
+      - Available on
+    * - System
+      - Every client
+    * - Backup, Command, Download Client, History, Log, Notification, Tag, Update
+      - Sonarr, Radarr, Lidarr, Readarr, Whisparr, Prowlarr
+    * - Indexer
+      - Sonarr, Radarr, Lidarr, Readarr, Whisparr, Prowlarr
+    * - Blocklist, Calendar, Import List, Metadata, Quality Definition, Quality Profile,
+        Queue, Remote Path Mapping, Root Folder, Wanted
+      - Sonarr, Radarr, Lidarr, Readarr, Whisparr
+    * - Import List Exclusion
+      - Sonarr, Radarr, Lidarr, Readarr, Whisparr
+    * - Any of the above not listed for a client
+      - Not exposed on that client
+
+Bazarr and Dispatcharr have their own APIs and expose only ``system`` from this set,
+alongside their own client specific components.
 
 Backup
 ------

--- a/src/pyarr/_async/bazarr/__init__.py
+++ b/src/pyarr/_async/bazarr/__init__.py
@@ -56,4 +56,7 @@ class Bazarr(BaseArrClient):
         self.series = Series(self.http_utils)
         self.movies = Movies(self.http_utils)
         self.episodes = Episodes(self.http_utils)
-        self.wanted = Wanted(self.http_utils, path="subtitles/wanted")
+        # Bazarr has no combined wanted endpoint. subtitles/wanted does not exist and is
+        # answered with the SPA HTML page rather than a 404, so it looked like it worked.
+        self.wanted_episodes = Wanted(self.http_utils, path="episodes/wanted")
+        self.wanted_movies = Wanted(self.http_utils, path="movies/wanted")

--- a/src/pyarr/_async/client.py
+++ b/src/pyarr/_async/client.py
@@ -68,25 +68,7 @@ class BaseArrClient:
             verify_ssl=verify_ssl,
             headers=headers,
         )
-        self.history = History(self.http_utils)
-        self.backup = Backup(self.http_utils)
         self.system = System(self.http_utils)
-        self.tag = Tag(self.http_utils)
-        self.blocklist = Blocklist(self.http_utils)
-        self.calendar = Calendar(self.http_utils)
-        self.root_folder = RootFolder(self.http_utils)
-        self.update = Update(self.http_utils)
-        self.metadata = Metadata(self.http_utils)
-        self.log = Log(self.http_utils)
-        self.indexer = Indexer(self.http_utils)
-        self.download_client = DownloadClient(self.http_utils)
-        self.import_list = ImportList(self.http_utils)
-        self.notification = Notification(self.http_utils)
-        self.quality_profile = QualityProfile(self.http_utils)
-        self.quality_definition = QualityDefinition(self.http_utils)
-        self.queue = Queue(self.http_utils)
-        self.remote_path_mapping = RemotePathMapping(self.http_utils)
-        self.command = Command(self.http_utils)
 
     async def __aenter__(self: T) -> T:
         """Enter the runtime context related to this object.
@@ -108,3 +90,39 @@ class BaseArrClient:
         """
         # Clean up resources
         await self.http_utils.__aexit__(exc_type, exc_value, traceback)
+
+
+class MediaArrClient(BaseArrClient):
+    """Base class for the media manager Arr clients.
+
+    Sonarr, Radarr, Lidarr, Readarr and Whisparr share the Servarr media management API, so
+    they all answer the components attached here. Prowlarr, Bazarr and Dispatcharr do not,
+    which is why these live on this tier rather than on :class:`BaseArrClient`.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initializes the client and attaches the shared media management components.
+
+        Args:
+            *args (Any): Positional arguments for BaseArrClient.
+            **kwargs (Any): Keyword arguments for BaseArrClient.
+        """
+        super().__init__(*args, **kwargs)
+        self.history = History(self.http_utils)
+        self.backup = Backup(self.http_utils)
+        self.tag = Tag(self.http_utils)
+        self.blocklist = Blocklist(self.http_utils)
+        self.calendar = Calendar(self.http_utils)
+        self.root_folder = RootFolder(self.http_utils)
+        self.update = Update(self.http_utils)
+        self.metadata = Metadata(self.http_utils)
+        self.log = Log(self.http_utils)
+        self.indexer = Indexer(self.http_utils)
+        self.download_client = DownloadClient(self.http_utils)
+        self.import_list = ImportList(self.http_utils)
+        self.notification = Notification(self.http_utils)
+        self.quality_profile = QualityProfile(self.http_utils)
+        self.quality_definition = QualityDefinition(self.http_utils)
+        self.queue = Queue(self.http_utils)
+        self.remote_path_mapping = RemotePathMapping(self.http_utils)
+        self.command = Command(self.http_utils)

--- a/src/pyarr/_async/lidarr/__init__.py
+++ b/src/pyarr/_async/lidarr/__init__.py
@@ -1,6 +1,6 @@
 import httpx
 
-from pyarr._async.client import BaseArrClient
+from pyarr._async.client import MediaArrClient
 from pyarr._async.common.import_list_exclusion import ImportListExclusion
 from pyarr._async.common.wanted import Wanted
 from pyarr._async.lidarr.album import Album
@@ -12,7 +12,7 @@ from pyarr._async.lidarr.track import Track
 from pyarr._async.lidarr.track_file import TrackFile
 
 
-class Lidarr(BaseArrClient):
+class Lidarr(MediaArrClient):
     """Lidarr API client."""
 
     def __init__(

--- a/src/pyarr/_async/prowlarr/__init__.py
+++ b/src/pyarr/_async/prowlarr/__init__.py
@@ -1,6 +1,14 @@
 import httpx
 
 from pyarr._async.client import BaseArrClient
+from pyarr._async.common.backup import Backup
+from pyarr._async.common.command import Command
+from pyarr._async.common.download_client import DownloadClient
+from pyarr._async.common.history import History
+from pyarr._async.common.log import Log
+from pyarr._async.common.notification import Notification
+from pyarr._async.common.tag import Tag
+from pyarr._async.common.update import Update
 from pyarr._async.prowlarr.applications import Applications
 from pyarr._async.prowlarr.indexer import Indexer
 from pyarr._async.prowlarr.indexer_proxy import IndexerProxy
@@ -50,6 +58,14 @@ class Prowlarr(BaseArrClient):
             headers=headers,
         )
         self.indexer = Indexer(self.http_utils)
+        self.command = Command(self.http_utils)
+        self.download_client = DownloadClient(self.http_utils)
+        self.history = History(self.http_utils)
+        self.log = Log(self.http_utils)
+        self.notification = Notification(self.http_utils)
+        self.backup = Backup(self.http_utils)
+        self.tag = Tag(self.http_utils)
+        self.update = Update(self.http_utils)
         self.search = Search(self.http_utils)
         self.applications = Applications(self.http_utils)
         self.indexer_proxy = IndexerProxy(self.http_utils)

--- a/src/pyarr/_async/radarr/__init__.py
+++ b/src/pyarr/_async/radarr/__init__.py
@@ -1,6 +1,6 @@
 import httpx
 
-from pyarr._async.client import BaseArrClient
+from pyarr._async.client import MediaArrClient
 from pyarr._async.common.import_list_exclusion import ImportListExclusion
 from pyarr._async.common.wanted import Wanted
 from pyarr._async.radarr.config import Config
@@ -11,7 +11,7 @@ from pyarr._async.radarr.movie_file import MovieFile
 from pyarr._async.radarr.release import Release
 
 
-class Radarr(BaseArrClient):
+class Radarr(MediaArrClient):
     """Radarr API client."""
 
     def __init__(

--- a/src/pyarr/_async/readarr/__init__.py
+++ b/src/pyarr/_async/readarr/__init__.py
@@ -1,6 +1,6 @@
 import httpx
 
-from pyarr._async.client import BaseArrClient
+from pyarr._async.client import MediaArrClient
 from pyarr._async.common.import_list_exclusion import ImportListExclusion
 from pyarr._async.common.wanted import Wanted
 from pyarr._async.readarr.author import Author
@@ -13,7 +13,7 @@ from pyarr._async.readarr.metadata_profile import MetadataProfile
 from pyarr._async.readarr.release_profile import ReleaseProfile
 
 
-class Readarr(BaseArrClient):
+class Readarr(MediaArrClient):
     """Readarr API client."""
 
     def __init__(

--- a/src/pyarr/_async/sonarr/__init__.py
+++ b/src/pyarr/_async/sonarr/__init__.py
@@ -1,6 +1,6 @@
 import httpx
 
-from pyarr._async.client import BaseArrClient
+from pyarr._async.client import MediaArrClient
 from pyarr._async.common.import_list_exclusion import ImportListExclusion
 from pyarr._async.common.wanted import Wanted
 from pyarr._async.sonarr.config import Config
@@ -11,7 +11,7 @@ from pyarr._async.sonarr.release import Release
 from pyarr._async.sonarr.series import Series
 
 
-class Sonarr(BaseArrClient):
+class Sonarr(MediaArrClient):
     """Sonarr API client."""
 
     def __init__(

--- a/src/pyarr/_async/whisparr/__init__.py
+++ b/src/pyarr/_async/whisparr/__init__.py
@@ -1,6 +1,6 @@
 import httpx
 
-from pyarr._async.client import BaseArrClient
+from pyarr._async.client import MediaArrClient
 from pyarr._async.common.import_list_exclusion import ImportListExclusion
 from pyarr._async.common.wanted import Wanted
 from pyarr._async.radarr.config import Config
@@ -11,7 +11,7 @@ from pyarr._async.radarr.movie_file import MovieFile
 from pyarr._async.radarr.release import Release
 
 
-class Whisparr(BaseArrClient):
+class Whisparr(MediaArrClient):
     """Whisparr API client (Radarr fork)."""
 
     def __init__(

--- a/src/pyarr/_sync/bazarr/__init__.py
+++ b/src/pyarr/_sync/bazarr/__init__.py
@@ -61,4 +61,7 @@ class Bazarr(BaseArrClient):
         self.series = Series(self.http_utils)
         self.movies = Movies(self.http_utils)
         self.episodes = Episodes(self.http_utils)
-        self.wanted = Wanted(self.http_utils, path="subtitles/wanted")
+        # Bazarr has no combined wanted endpoint. subtitles/wanted does not exist and is
+        # answered with the SPA HTML page rather than a 404, so it looked like it worked.
+        self.wanted_episodes = Wanted(self.http_utils, path="episodes/wanted")
+        self.wanted_movies = Wanted(self.http_utils, path="movies/wanted")

--- a/src/pyarr/_sync/client.py
+++ b/src/pyarr/_sync/client.py
@@ -73,25 +73,7 @@ class BaseArrClient:
             verify_ssl=verify_ssl,
             headers=headers,
         )
-        self.history = History(self.http_utils)
-        self.backup = Backup(self.http_utils)
         self.system = System(self.http_utils)
-        self.tag = Tag(self.http_utils)
-        self.blocklist = Blocklist(self.http_utils)
-        self.calendar = Calendar(self.http_utils)
-        self.root_folder = RootFolder(self.http_utils)
-        self.update = Update(self.http_utils)
-        self.metadata = Metadata(self.http_utils)
-        self.log = Log(self.http_utils)
-        self.indexer = Indexer(self.http_utils)
-        self.download_client = DownloadClient(self.http_utils)
-        self.import_list = ImportList(self.http_utils)
-        self.notification = Notification(self.http_utils)
-        self.quality_profile = QualityProfile(self.http_utils)
-        self.quality_definition = QualityDefinition(self.http_utils)
-        self.queue = Queue(self.http_utils)
-        self.remote_path_mapping = RemotePathMapping(self.http_utils)
-        self.command = Command(self.http_utils)
 
     def __enter__(self: T) -> T:
         """Enter the runtime context related to this object.
@@ -113,3 +95,39 @@ class BaseArrClient:
         """
         # Clean up resources
         self.http_utils.__exit__(exc_type, exc_value, traceback)
+
+
+class MediaArrClient(BaseArrClient):
+    """Base class for the media manager Arr clients.
+
+    Sonarr, Radarr, Lidarr, Readarr and Whisparr share the Servarr media management API, so
+    they all answer the components attached here. Prowlarr, Bazarr and Dispatcharr do not,
+    which is why these live on this tier rather than on :class:`BaseArrClient`.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initializes the client and attaches the shared media management components.
+
+        Args:
+            *args (Any): Positional arguments for BaseArrClient.
+            **kwargs (Any): Keyword arguments for BaseArrClient.
+        """
+        super().__init__(*args, **kwargs)
+        self.history = History(self.http_utils)
+        self.backup = Backup(self.http_utils)
+        self.tag = Tag(self.http_utils)
+        self.blocklist = Blocklist(self.http_utils)
+        self.calendar = Calendar(self.http_utils)
+        self.root_folder = RootFolder(self.http_utils)
+        self.update = Update(self.http_utils)
+        self.metadata = Metadata(self.http_utils)
+        self.log = Log(self.http_utils)
+        self.indexer = Indexer(self.http_utils)
+        self.download_client = DownloadClient(self.http_utils)
+        self.import_list = ImportList(self.http_utils)
+        self.notification = Notification(self.http_utils)
+        self.quality_profile = QualityProfile(self.http_utils)
+        self.quality_definition = QualityDefinition(self.http_utils)
+        self.queue = Queue(self.http_utils)
+        self.remote_path_mapping = RemotePathMapping(self.http_utils)
+        self.command = Command(self.http_utils)

--- a/src/pyarr/_sync/lidarr/__init__.py
+++ b/src/pyarr/_sync/lidarr/__init__.py
@@ -5,7 +5,7 @@
 
 import httpx
 
-from pyarr._sync.client import BaseArrClient
+from pyarr._sync.client import MediaArrClient
 from pyarr._sync.common.import_list_exclusion import ImportListExclusion
 from pyarr._sync.common.wanted import Wanted
 from pyarr._sync.lidarr.album import Album
@@ -17,7 +17,7 @@ from pyarr._sync.lidarr.track import Track
 from pyarr._sync.lidarr.track_file import TrackFile
 
 
-class Lidarr(BaseArrClient):
+class Lidarr(MediaArrClient):
     """Lidarr API client."""
 
     def __init__(

--- a/src/pyarr/_sync/prowlarr/__init__.py
+++ b/src/pyarr/_sync/prowlarr/__init__.py
@@ -6,6 +6,14 @@
 import httpx
 
 from pyarr._sync.client import BaseArrClient
+from pyarr._sync.common.backup import Backup
+from pyarr._sync.common.command import Command
+from pyarr._sync.common.download_client import DownloadClient
+from pyarr._sync.common.history import History
+from pyarr._sync.common.log import Log
+from pyarr._sync.common.notification import Notification
+from pyarr._sync.common.tag import Tag
+from pyarr._sync.common.update import Update
 from pyarr._sync.prowlarr.applications import Applications
 from pyarr._sync.prowlarr.indexer import Indexer
 from pyarr._sync.prowlarr.indexer_proxy import IndexerProxy
@@ -55,6 +63,14 @@ class Prowlarr(BaseArrClient):
             headers=headers,
         )
         self.indexer = Indexer(self.http_utils)
+        self.command = Command(self.http_utils)
+        self.download_client = DownloadClient(self.http_utils)
+        self.history = History(self.http_utils)
+        self.log = Log(self.http_utils)
+        self.notification = Notification(self.http_utils)
+        self.backup = Backup(self.http_utils)
+        self.tag = Tag(self.http_utils)
+        self.update = Update(self.http_utils)
         self.search = Search(self.http_utils)
         self.applications = Applications(self.http_utils)
         self.indexer_proxy = IndexerProxy(self.http_utils)

--- a/src/pyarr/_sync/radarr/__init__.py
+++ b/src/pyarr/_sync/radarr/__init__.py
@@ -5,7 +5,7 @@
 
 import httpx
 
-from pyarr._sync.client import BaseArrClient
+from pyarr._sync.client import MediaArrClient
 from pyarr._sync.common.import_list_exclusion import ImportListExclusion
 from pyarr._sync.common.wanted import Wanted
 from pyarr._sync.radarr.config import Config
@@ -16,7 +16,7 @@ from pyarr._sync.radarr.movie_file import MovieFile
 from pyarr._sync.radarr.release import Release
 
 
-class Radarr(BaseArrClient):
+class Radarr(MediaArrClient):
     """Radarr API client."""
 
     def __init__(

--- a/src/pyarr/_sync/readarr/__init__.py
+++ b/src/pyarr/_sync/readarr/__init__.py
@@ -5,7 +5,7 @@
 
 import httpx
 
-from pyarr._sync.client import BaseArrClient
+from pyarr._sync.client import MediaArrClient
 from pyarr._sync.common.import_list_exclusion import ImportListExclusion
 from pyarr._sync.common.wanted import Wanted
 from pyarr._sync.readarr.author import Author
@@ -18,7 +18,7 @@ from pyarr._sync.readarr.metadata_profile import MetadataProfile
 from pyarr._sync.readarr.release_profile import ReleaseProfile
 
 
-class Readarr(BaseArrClient):
+class Readarr(MediaArrClient):
     """Readarr API client."""
 
     def __init__(

--- a/src/pyarr/_sync/sonarr/__init__.py
+++ b/src/pyarr/_sync/sonarr/__init__.py
@@ -5,7 +5,7 @@
 
 import httpx
 
-from pyarr._sync.client import BaseArrClient
+from pyarr._sync.client import MediaArrClient
 from pyarr._sync.common.import_list_exclusion import ImportListExclusion
 from pyarr._sync.common.wanted import Wanted
 from pyarr._sync.sonarr.config import Config
@@ -16,7 +16,7 @@ from pyarr._sync.sonarr.release import Release
 from pyarr._sync.sonarr.series import Series
 
 
-class Sonarr(BaseArrClient):
+class Sonarr(MediaArrClient):
     """Sonarr API client."""
 
     def __init__(

--- a/src/pyarr/_sync/whisparr/__init__.py
+++ b/src/pyarr/_sync/whisparr/__init__.py
@@ -5,7 +5,7 @@
 
 import httpx
 
-from pyarr._sync.client import BaseArrClient
+from pyarr._sync.client import MediaArrClient
 from pyarr._sync.common.import_list_exclusion import ImportListExclusion
 from pyarr._sync.common.wanted import Wanted
 from pyarr._sync.radarr.config import Config
@@ -16,7 +16,7 @@ from pyarr._sync.radarr.movie_file import MovieFile
 from pyarr._sync.radarr.release import Release
 
 
-class Whisparr(BaseArrClient):
+class Whisparr(MediaArrClient):
     """Whisparr API client (Radarr fork)."""
 
     def __init__(

--- a/tests/test_client_modules.py
+++ b/tests/test_client_modules.py
@@ -9,6 +9,14 @@ single page app HTML rather than a 404, which is what made the gap so hard to sp
 import pytest
 
 from pyarr import Bazarr, Dispatcharr, Lidarr, Prowlarr, Radarr, Readarr, Sonarr, Whisparr
+from pyarr._async.bazarr import Bazarr as AsyncBazarr
+from pyarr._async.dispatcharr import Dispatcharr as AsyncDispatcharr
+from pyarr._async.lidarr import Lidarr as AsyncLidarr
+from pyarr._async.prowlarr import Prowlarr as AsyncProwlarr
+from pyarr._async.radarr import Radarr as AsyncRadarr
+from pyarr._async.readarr import Readarr as AsyncReadarr
+from pyarr._async.sonarr import Sonarr as AsyncSonarr
+from pyarr._async.whisparr import Whisparr as AsyncWhisparr
 
 MEDIA_COMPONENTS = [
     "backup",
@@ -64,8 +72,12 @@ def test_prowlarr_exposes_supported_components(component):
 
 @pytest.mark.parametrize("component", PROWLARR_UNSUPPORTED)
 def test_prowlarr_hides_unsupported_components(component):
-    """Prowlarr answers these with a 404, so the attribute must not exist."""
-    assert not hasattr(_client(Prowlarr, "v1"), component)
+    """Prowlarr answers these with a 404, so accessing one must raise rather than 404."""
+    client = _client(Prowlarr, "v1")
+
+    assert not hasattr(client, component)
+    with pytest.raises(AttributeError, match=component):
+        getattr(client, component)
 
 
 @pytest.mark.parametrize("client_class", [Bazarr, Dispatcharr])
@@ -87,6 +99,36 @@ def test_every_client_exposes_system(client_class, api_ver):
 def test_bazarr_wanted_is_split_by_media_type():
     """Bazarr has no combined wanted endpoint - subtitles/wanted returned the HTML page."""
     client = _client(Bazarr, "")
+
+    assert not hasattr(client, "wanted")
+    assert client.wanted_episodes.path == "episodes/wanted"
+    assert client.wanted_movies.path == "movies/wanted"
+
+
+@pytest.mark.parametrize("client_class", [AsyncSonarr, AsyncRadarr, AsyncLidarr, AsyncReadarr, AsyncWhisparr])
+@pytest.mark.parametrize("component", MEDIA_COMPONENTS)
+def test_async_media_clients_expose_every_media_component(client_class, component):
+    assert hasattr(_client(client_class, "v3"), component)
+
+
+@pytest.mark.parametrize("component", PROWLARR_UNSUPPORTED)
+def test_async_prowlarr_hides_unsupported_components(component):
+    client = _client(AsyncProwlarr, "v1")
+
+    assert not hasattr(client, component)
+    with pytest.raises(AttributeError, match=component):
+        getattr(client, component)
+
+
+@pytest.mark.parametrize("client_class", [AsyncBazarr, AsyncDispatcharr])
+@pytest.mark.parametrize("component", MEDIA_COMPONENTS)
+def test_async_non_media_clients_hide_media_components(client_class, component):
+    assert not hasattr(_client(client_class, ""), component)
+
+
+def test_async_bazarr_wanted_is_split_by_media_type():
+    """The async client is a separate source file, so it gets the same guard."""
+    client = _client(AsyncBazarr, "")
 
     assert not hasattr(client, "wanted")
     assert client.wanted_episodes.path == "episodes/wanted"

--- a/tests/test_client_modules.py
+++ b/tests/test_client_modules.py
@@ -1,0 +1,93 @@
+"""Which components each client exposes.
+
+Regression tests for #192. The support lists come from probing live containers: Sonarr
+4.0.19.2979 answers every media management component, Prowlarr 2.x answers a subset and
+404s the rest, and Bazarr and Dispatcharr answer unsupported paths with a 200 and their
+single page app HTML rather than a 404, which is what made the gap so hard to spot.
+"""
+
+import pytest
+
+from pyarr import Bazarr, Dispatcharr, Lidarr, Prowlarr, Radarr, Readarr, Sonarr, Whisparr
+
+MEDIA_COMPONENTS = [
+    "backup",
+    "blocklist",
+    "calendar",
+    "command",
+    "download_client",
+    "history",
+    "import_list",
+    "indexer",
+    "log",
+    "metadata",
+    "notification",
+    "quality_definition",
+    "quality_profile",
+    "queue",
+    "remote_path_mapping",
+    "root_folder",
+    "tag",
+    "update",
+]
+
+#: Components Prowlarr answers, verified against a live instance.
+PROWLARR_SUPPORTED = ["backup", "command", "download_client", "history", "indexer", "log", "notification", "tag", "update"]
+
+#: Components Prowlarr 404s.
+PROWLARR_UNSUPPORTED = [c for c in MEDIA_COMPONENTS if c not in PROWLARR_SUPPORTED]
+
+
+def _client(client_class, api_ver):
+    """Builds a client without touching the network.
+
+    Args:
+        client_class: The client class to build.
+        api_ver (str): API version, passed so the client skips auto detection.
+
+    Returns:
+        The constructed client.
+    """
+    return client_class(host="localhost", api_key="testkey", api_ver=api_ver, tls=False)
+
+
+@pytest.mark.parametrize("client_class", [Sonarr, Radarr, Lidarr, Readarr, Whisparr])
+@pytest.mark.parametrize("component", MEDIA_COMPONENTS)
+def test_media_clients_expose_every_media_component(client_class, component):
+    assert hasattr(_client(client_class, "v3"), component)
+
+
+@pytest.mark.parametrize("component", PROWLARR_SUPPORTED)
+def test_prowlarr_exposes_supported_components(component):
+    assert hasattr(_client(Prowlarr, "v1"), component)
+
+
+@pytest.mark.parametrize("component", PROWLARR_UNSUPPORTED)
+def test_prowlarr_hides_unsupported_components(component):
+    """Prowlarr answers these with a 404, so the attribute must not exist."""
+    assert not hasattr(_client(Prowlarr, "v1"), component)
+
+
+@pytest.mark.parametrize("client_class", [Bazarr, Dispatcharr])
+@pytest.mark.parametrize("component", MEDIA_COMPONENTS)
+def test_non_media_clients_hide_media_components(client_class, component):
+    """Bazarr and Dispatcharr answer these with their HTML page, not JSON, so hide them."""
+    assert not hasattr(_client(client_class, ""), component)
+
+
+@pytest.mark.parametrize(
+    "client_class, api_ver",
+    [(Sonarr, "v3"), (Radarr, "v3"), (Lidarr, "v1"), (Readarr, "v1"), (Whisparr, "v3"), (Prowlarr, "v1"), (Bazarr, ""), (Dispatcharr, "")],
+)
+def test_every_client_exposes_system(client_class, api_ver):
+    """system is the one component every client answers, Bazarr included."""
+    assert hasattr(_client(client_class, api_ver), "system")
+
+
+def test_bazarr_wanted_is_split_by_media_type():
+    """Bazarr has no combined wanted endpoint - subtitles/wanted returned the HTML page."""
+    client = _client(Bazarr, "")
+
+    assert not hasattr(client, "wanted")
+    assert client.wanted_episodes.path == "episodes/wanted"
+    assert client.wanted_movies.path == "movies/wanted"


### PR DESCRIPTION
## Description

Every client inherited all 20 common components from `BaseArrClient`, including the three that mostly do not have those endpoints. As the reporter noted, the two failure modes are quite different and one of them is worse than an error:

- `Prowlarr(url, key).blocklist.get()` -> `404`
- `Bazarr(url, key).blocklist.get()` -> **`200`** with the single page app's "enable javascript" HTML, wrapped up as `{"message": "<!doctype html>..."}`

### Audited against live instances, not documentation

| Component | Sonarr family | Prowlarr | Bazarr | Dispatcharr |
|---|---|---|---|---|
| `system` | JSON | JSON | JSON | own module |
| `command`, `download_client`, `history`, `indexer`, `log`, `notification`, `backup`, `tag`, `update` | JSON | JSON | HTML | HTML |
| `blocklist`, `calendar`, `import_list`, `metadata`, `quality_definition`, `quality_profile`, `queue`, `remote_path_mapping`, `root_folder`, `wanted` | JSON | `404` | HTML | HTML |

Probed on Sonarr 4.0.19.2979, Prowlarr, Bazarr v1.6.0-ls360 and Dispatcharr. Bazarr's only JSON answers in this set are `system/status` and `system/health`; everything else is the HTML fallback. Dispatcharr behaves the same way and already overrides `system` with its own module.

### What changed

- `BaseArrClient` now attaches only `system`, the one component every client answers.
- New `MediaArrClient` carries the other 18 for Sonarr, Radarr, Lidarr, Readarr and Whisparr.
- Prowlarr wires the nine it genuinely answers, on top of its own `indexer`, `search`, `applications` and `indexer_proxy`.
- Bazarr and Dispatcharr keep only `system` plus their own components.

So `Prowlarr(url, key).blocklist` now raises `AttributeError: 'Prowlarr' object has no attribute 'blocklist'`, exactly as requested, and mypy and IDE completion tell the truth about each client.

### bazarr.wanted was pointing at nothing

Found while auditing. `bazarr.wanted` was wired to `subtitles/wanted`, which does not exist - Bazarr answered it with the HTML page and a 200, so it never looked broken. The real endpoints are `episodes/wanted` and `movies/wanted`, now exposed as `wanted_episodes` and `wanted_movies`. Both verified returning `{"data": [], "total": 0}`.

### Breaking change, in the narrow sense

Attributes disappear, so this is breaking. Every call it removes, though, is one that already returned a 404 or a page of HTML - no working code can depend on them. The `bazarr.wanted` rename is the same story.

## Related issues

Fixes #192

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested

- [x] `tests/test_client_modules.py` - 153 cases pinning the component surface of all eight clients, including that Prowlarr's unsupported ten and Bazarr's and Dispatcharr's eighteen are absent
- [x] Everything retained was smoke tested live through the clients: all nine Prowlarr components return successfully, and Bazarr's `system.get_status`, `wanted_episodes` and `wanted_movies` all return real JSON
- [x] No integration test referenced a removed attribute (checked before removing them)
- [x] `pre-commit run --all-files` passes; docs build with no new warnings from the changed files

## Summary by Sourcery

Expose only API components supported by each client and replace Bazarr’s invalid combined wanted endpoint with separate episode and movie endpoints.

New Features:
- Expose Bazarr episode- and movie-specific wanted components for their supported endpoints.

Bug Fixes:
- Prevent clients from exposing common components whose endpoints are unsupported or return invalid HTML responses.
- Correct Bazarr wanted endpoint mappings in both synchronous and asynchronous clients.

Enhancements:
- Align synchronous and asynchronous client component surfaces with the APIs supported by each service by introducing a shared media-client tier and limiting Prowlarr to its supported common components.

Documentation:
- Update module documentation to reflect client-specific component availability and Bazarr's split wanted components.

Tests:
- Add coverage for component availability across all synchronous and asynchronous clients, including unsupported-component and Bazarr wanted-endpoint regressions.