### PR TITLE
chore: ignore .claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ tests/docker_configs/jackett/*
 !tests/docker_configs/jackett/config/jackett/Jackett/ServerConfig.json
 core.*
 dispatcharr-api.yaml
+
+# Claude Code local state and agent worktrees
+.claude/


### PR DESCRIPTION
## Description

`.claude/` is untracked and unignored, so it shows up in every `git status` and, worse, an unguarded `git add -A` stages the agent worktrees under `.claude/worktrees/` as embedded git repositories. I hit that myself while working on #209.

Nothing under `.claude/` is currently tracked, so this changes nothing that exists - it only stops the directory being offered up. If you ever want to share project level Claude config, swap the rule for `.claude/*` plus a `!.claude/settings.json` exception.

## Type of change

- [x] CI / Tests update

## How has this been tested

- [x] `git status` no longer lists `.claude/`
- [x] `git ls-files .claude` was empty beforehand, so no tracked file becomes ignored

## Summary by Sourcery

Enhancements:
- Ignore the untracked `.claude/` directory to keep agent worktrees and project-local Claude files out of Git status and accidental staging.